### PR TITLE
Add `subtype` as optional to the dividend and interest transactions

### DIFF
--- a/src/core/FieldRequirements.ts
+++ b/src/core/FieldRequirements.ts
@@ -167,7 +167,7 @@ const COMMON_FIELD_REQUIREMENTS: Pick<
  * Field requirements for each activity type, based on Wealthfolio documentation
  *
  * Source: https://github.com/afadil/wealthfolio/blob/main/docs/activities/activity-types.md
- * Last update: 2026-02-21
+ * Last update: 2026-04-06
  */
 const RECORD_FIELD_REQUIREMENTS: {
   [key in ActivityType]: WealthfolioRecordFieldRequirements;
@@ -199,6 +199,7 @@ const RECORD_FIELD_REQUIREMENTS: {
         ? FieldRequirement.Required
         : FieldRequirement.Ignored,
     amount: FieldRequirement.Required,
+    subtype: FieldRequirement.Optional,
     metadata: (record) =>
       // Dividend in kind requires metadata with `received_asset_id` to know which asset was
       // received as dividends
@@ -219,6 +220,7 @@ const RECORD_FIELD_REQUIREMENTS: {
         ? FieldRequirement.Required
         : FieldRequirement.Ignored,
     amount: FieldRequirement.Required,
+    subtype: FieldRequirement.Optional,
   },
   [ActivityType.Deposit]: {
     ...COMMON_FIELD_REQUIREMENTS,

--- a/tests/core/FieldRequirements.test.ts
+++ b/tests/core/FieldRequirements.test.ts
@@ -207,6 +207,56 @@ describe("FieldRequirements", () => {
       expect(Number.isNaN(record.unitPrice)).toBe(true);
     });
 
+    it("should preserve subtype for activities where subtype is optional", () => {
+      const cases: Array<{ activityType: ActivityType; subtype: ActivitySubtype }> = [
+        { activityType: ActivityType.Dividend, subtype: ActivitySubtype.DRIP },
+        { activityType: ActivityType.Interest, subtype: ActivitySubtype.StakingReward },
+        { activityType: ActivityType.Fee, subtype: ActivitySubtype.ManagementFee },
+        { activityType: ActivityType.Tax, subtype: ActivitySubtype.Withholding },
+        { activityType: ActivityType.Credit, subtype: ActivitySubtype.Bonus },
+        { activityType: ActivityType.Adjustment, subtype: ActivitySubtype.Refund },
+        { activityType: ActivityType.Unknown, subtype: ActivitySubtype.Rebate },
+      ];
+
+      for (const { activityType, subtype } of cases) {
+        const record = createRecord({
+          activityType,
+          subtype,
+          amount: 100,
+        });
+
+        const result = validateRecordFieldRequirements(record, true);
+
+        expect(result.valid).toBe(true);
+        expect(record.subtype).toBe(subtype);
+      }
+    });
+
+    it("should clear subtype for activities where subtype is ignored", () => {
+      const cases: ActivityType[] = [
+        ActivityType.Buy,
+        ActivityType.Sell,
+        ActivityType.Deposit,
+        ActivityType.Withdrawal,
+        ActivityType.TransferIn,
+        ActivityType.TransferOut,
+        ActivityType.Split,
+      ];
+
+      for (const activityType of cases) {
+        const record = createRecord({
+          activityType,
+          subtype: ActivitySubtype.DRIP,
+          amount: 100,
+        });
+
+        const result = validateRecordFieldRequirements(record, true);
+
+        expect(result.valid).toBe(true);
+        expect(record.subtype).toBe("");
+      }
+    });
+
     it("should enforce transfer requirements based on symbol presence", () => {
       const withSymbol = createRecord({
         activityType: ActivityType.TransferIn,


### PR DESCRIPTION
## Description

Add `subtype` as an optional field to the dividend and interest transactions.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New format plugin (adds support for a new CSV format)
- [ ] New data provider (adds support for a new data source for looking up symbols, etc.)
- [ ] Improvement or enhancement to existing functionality (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (project maintenance, build configuration, etc.)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CODE_OF_CONDUCT.md) and agree to abide by it
- [x] I agree that my contributions will be licensed under the **BSD 3-Clause License**
- [x] My code follows the project's [coding style and conventions](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md#contributing)
- [x] All new code has adequate test coverage
- [x] All existing tests pass locally
- [x] My commits have clear and descriptive commit messages
- [x] My commits are atomic, i.e. complete and self-contained units of change (else, meld the commits before submitting the PR)

## Additional Notes

Somehow I overlooked this when adding field requirements.

---

By submitting this pull request, I confirm that I have read and understood the [contribution guidelines](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md) and that my contributions are my own work.