### PR TITLE
Add `--no-color` and `--color` CLI options

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -27,6 +27,9 @@ Upcoming release.
   in March 2026.
 - New optional `InstrumentType` column in the Generic format plugin. If not
   present or empty, it will be converted to an empty value in the output CSV.
+- Ability to explicitly disable or force colored output via CLI options
+  (`--no-color` and `--color`) or environment variables (`NO_COLOR` and
+  `FORCE_COLOR`).
 
 ### Fixed
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -22,6 +22,7 @@ SPDX-License-Identifier: BSD-3-Clause
   - [Get Help](#get-help)
   - [Global Options](#global-options)
     - [Set Log Verbosity](#set-log-verbosity)
+    - [Control Colored Output](#control-colored-output)
 - [Update](#update)
   - [Update From npmjs.com](#update-from-npmjscom)
   - [Update From Source](#update-from-source)
@@ -286,6 +287,35 @@ E.g., you can redirect logs to a file while keeping user-facing output in the co
 ```bash
 convert-to-wealthfolio convert examples/sample-generic.csv output.csv -- --log-level DEBUG 2> converter.log
 ```
+
+#### Control Colored Output
+
+By default, the converter outputs colorized text when run in an interactive shell and it supports color output. You can explicitly disable or force colored output using the `--no-color` and `--color` options:
+
+Disable colored output:
+
+```bash
+convert-to-wealthfolio --no-color <command-and-arguments>
+```
+
+Force colored output (e.g., when piping output):
+
+```bash
+convert-to-wealthfolio --color <command-and-arguments>
+```
+
+You can also control colored output using environment variables:
+
+- `NO_COLOR` - Set to any non-empty value to disable colored output (equivalent to `--no-color`). This follows the [no-color.org](https://no-color.org) convention.
+- `FORCE_COLOR` - Set to any non-empty value to force colored output (equivalent to `--color`). This may be useful when color support was not detected automatically.
+
+E.g., disable color using an environment variable:
+
+```bash
+NO_COLOR=1 convert-to-wealthfolio convert examples/sample-generic.csv output.csv
+```
+
+**Note:** The `NO_COLOR` environment variable takes precedence over _all_ other color options, as per the convention. The `--no-color` CLI option takes precedence over both the `FORCE_COLOR` environment variable and the `--color` CLI option. The `FORCE_COLOR` environment variable only takes precedence over the `--color` CLI option.
 
 ## Update
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,9 @@ program
     new Option("--trace", "Set log verbosity to TRACE, overrides --log-level")
       .implies({ logLevel: "TRACE" })
       .conflicts("debug"),
-  );
+  )
+  .addOption(new Option("--no-color", "Disable colored output").env("NO_COLOR"))
+  .addOption(new Option("--color", "Force colored output").env("FORCE_COLOR"));
 
 program
   .command("convert")


### PR DESCRIPTION
## Description

Add possibility to explicitly disable or force the colored output:
- `--no-color` command-line option or `NO_COLOR` environment variable will disable it.
- `--color` command-line option or `FORCE_COLOR` environment variable will force it.

If none of the options or variables are set, the CLI will fallback to auto-detecting the color support in the terminal.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New format plugin (adds support for a new CSV format)
- [ ] New data provider (adds support for a new data source for looking up symbols, etc.)
- [x] Improvement or enhancement to existing functionality (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (project maintenance, build configuration, etc.)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CODE_OF_CONDUCT.md) and agree to abide by it
- [x] I agree that my contributions will be licensed under the **BSD 3-Clause License**
- [x] My code follows the project's [coding style and conventions](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md#contributing)
- ~~[ ] I have added [JSDoc](https://jsdoc.app/) documentation for any new functions, classes, or methods~~
- [x] I have updated relevant documentation (README, ChangeLog, docs/, etc.)
- [x] I have written tests for my changes
- [x] All new code has adequate test coverage
- [x] All existing tests pass locally
- [x] My commits have clear and descriptive commit messages
- [x] My commits are atomic, i.e. complete and self-contained units of change (else, meld the commits before submitting the PR)

---

By submitting this pull request, I confirm that I have read and understood the [contribution guidelines](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md) and that my contributions are my own work.