### PR TITLE
Add support for setting options through environment variables

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,18 @@ and this project adheres to
 
 Upcoming release.
 
+### Added
+
+- Environment variables to control their respective CLI options:
+  - `CTW_LOG_LEVEL` - Sets the log level (equivalent to `--log-level`).
+  - `CTW_FORMAT` - Sets the format plugin name (equivalent to `--format`).
+  - `CTW_DEFAULT_CURRENCY` - Sets the default currency (equivalent to
+    `--default-currency`).
+  - `CTW_OVERRIDES` - Sets the path to the overrides file (equivalent to
+    `--overrides`).
+
+  CLI options take precedence over environment variables when both are set.
+
 ## [0.2.0] - 2026-04-09
 
 This release adds support for transaction history exported from the

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -138,6 +138,14 @@ E.g., specify format as _Generic_:
 convert-to-wealthfolio convert --format Generic examples/sample-generic.csv output.csv
 ```
 
+You can also set the format using the `CTW_FORMAT` environment variable:
+
+```bash
+CTW_FORMAT=Generic convert-to-wealthfolio convert examples/sample-generic.csv output.csv
+```
+
+**Note:** The CLI option takes precedence over the environment variable if both are set.
+
 #### Specify the Default Currency
 
 You can specify a default currency code to use when the input CSV doesn't specify a currency for a record by using the `--default-currency` option:
@@ -153,6 +161,14 @@ E.g., use British Pound as default currency:
 ```bash
 convert-to-wealthfolio convert --default-currency GBP examples/sample-generic.csv output.csv
 ```
+
+You can also set the default currency using the `CTW_DEFAULT_CURRENCY` environment variable:
+
+```bash
+CTW_DEFAULT_CURRENCY=GBP convert-to-wealthfolio convert examples/sample-generic.csv output.csv
+```
+
+**Note:** The CLI option takes precedence over the environment variable if both are set.
 
 **Note:** Some formats may ignore the default currency option and always use their own. Always refer to the documentation of the specific format you're using.
 
@@ -197,6 +213,14 @@ This option is useful for:
 - Mapping ISIN, CUSIP, or company name to a symbol when the original symbol is missing in the source data
 
 See [examples/overrides.ini](../examples/overrides.ini) for a template.
+
+You can also set the path to the overrides file using the `CTW_OVERRIDES` environment variable:
+
+```bash
+CTW_OVERRIDES="examples/overrides.ini" convert-to-wealthfolio convert examples/sample-generic-isin-cusip-name.csv output.csv
+```
+
+**Note:** The CLI option takes precedence over the environment variable if both are set.
 
 **Note**: ISIN, CUSIP, and company name lookups are handled by plugins during conversion. Symbol overrides, on the other hand, are done automatically _after_ the conversion. So if you have an ISIN that resolves to a symbol, and that symbol is in the overrides, the override will be applied to the resolved symbol.
 
@@ -279,6 +303,16 @@ convert-to-wealthfolio --debug <command-and-arguments>
 # Set log verbosity to TRACE:
 convert-to-wealthfolio --trace <command-and-arguments>
 ```
+
+You can also set the log verbosity using the `CTW_LOG_LEVEL` environment variable, which accepts the same values as `--log-level`.
+
+E.g., set log verbosity using an environment variable:
+
+```bash
+CTW_LOG_LEVEL=DEBUG convert-to-wealthfolio convert examples/sample-generic.csv output.csv
+```
+
+**Note:** The CLI option takes precedence over the environment variable if both are set.
 
 **Note:** Log messages go to `stderr` to separate them from user-facing output, which goes to `stdout`. This allows you to redirect logs and output independently if needed.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ program
   .helpCommand("help <command>", "Show help for a specific command")
   .addOption(
     new Option("-l, --log-level <level>", "Set log verbosity level")
+      .env("CTW_LOG_LEVEL")
       // The lowest log level is ERROR, as ERROR and FATAL messages should always be shown
       .choices(["ERROR", "WARN", "INFO", "DEBUG", "TRACE"])
       .default("INFO"),
@@ -58,10 +59,9 @@ program
   .argument("<output>", "Output CSV file path")
   .description("Convert input CSV for import to Wealthfolio")
   .addOption(
-    new Option(
-      "-f, --format <format>",
-      "Format to use for conversion (skip autodetection)",
-    ).choices(formats.map((f) => f.getName())),
+    new Option("-f, --format <format>", "Format to use for conversion (skip autodetection)")
+      .env("CTW_FORMAT")
+      .choices(formats.map((f) => f.getName())),
   )
   .addOption(
     new Option(
@@ -76,11 +76,14 @@ program
         }
         return currency.toUpperCase();
       })
+      .env("CTW_DEFAULT_CURRENCY")
       .default(DEFAULT_CURRENCY),
   )
-  .option(
-    "-o, --overrides <path>",
-    "Path to INI file with symbol overrides and ISIN, CUSIP, and company name mappings",
+  .addOption(
+    new Option(
+      "-o, --overrides <path>",
+      "Path to INI file with symbol overrides and ISIN, CUSIP, and company name mappings",
+    ).env("CTW_OVERRIDES"),
   )
   .action(
     async (


### PR DESCRIPTION
## Description

- Environment variables to control their respective CLI options:
  - `CTW_LOG_LEVEL` - Sets the log level (equivalent to `--log-level`).
  - `CTW_FORMAT` - Sets the format plugin name (equivalent to `--format`).
  - `CTW_DEFAULT_CURRENCY` - Sets the default currency (equivalent to `--default-currency`).
  - `CTW_OVERRIDES` - Sets the path to the overrides file (equivalent to `--overrides`).

  CLI options take precedence over environment variables when both are set.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New format plugin (adds support for a new CSV format)
- [ ] New data provider (adds support for a new data source for looking up symbols, etc.)
- [x] Improvement or enhancement to existing functionality (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (project maintenance, build configuration, etc.)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CODE_OF_CONDUCT.md) and agree to abide by it
- [x] I agree that my contributions will be licensed under the **BSD 3-Clause License**
- [x] My code follows the project's [coding style and conventions](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md#contributing)
- ~~[ ] I have added [JSDoc](https://jsdoc.app/) documentation for any new functions, classes, or methods~~
- [x] I have updated relevant documentation (README, ChangeLog, docs/, etc.)
- ~~[ ] I have written tests for my changes~~
- ~~[ ] All new code has adequate test coverage~~
- [x] All existing tests pass locally
- [x] My commits have clear and descriptive commit messages
- [x] My commits are atomic, i.e. complete and self-contained units of change (else, meld the commits before submitting the PR)

---

By submitting this pull request, I confirm that I have read and understood the [contribution guidelines](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md) and that my contributions are my own work.
