### PR TITLE
Add symbol resolution caching

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,7 +21,16 @@ Upcoming release.
 
 ### Added
 
-- Environment variables to control their respective CLI options:
+- **Symbol resolution caching** - once a symbol is resolved, it will be cached
+  in-memory for the duration of the converter's execution. This means that if
+  the same symbol appears multiple times in the input CSV, it will only be
+  resolved once, and all subsequent occurrences will use the cached value. The
+  cache is based on the combination of symbol, ISIN, CUSIP, and company name
+  (after normalization - see below), which means that if one transaction
+  contains only ISIN and another transaction contains a combination of ISIN and
+  CUSIP, the resolution will be performed separately for each of them.
+
+- **Environment variables** to control their respective CLI options:
   - `CTW_LOG_LEVEL` - Sets the log level (equivalent to `--log-level`).
   - `CTW_FORMAT` - Sets the format plugin name (equivalent to `--format`).
   - `CTW_DEFAULT_CURRENCY` - Sets the default currency (equivalent to
@@ -30,6 +39,24 @@ Upcoming release.
     `--overrides`).
 
   CLI options take precedence over environment variables when both are set.
+
+### Changed
+
+- **Symbol normalization** - before querying providers or looking up the cache,
+  the converter now normalizes query fields: symbol, ISIN, and CUSIP are trimmed
+  and converted to uppercase; company name is only trimmed. As a result,
+  identifier values that differ only in whitespace or casing (e.g.,
+  `" us0378331005 "` and `"US0378331005"`) are treated the same and share a
+  single cache entry.
+
+- As a consequence of the symbol resolution caching and normalization, there are
+  also changes to the way symbol resolution is logged:
+  - When symbol is queried for the first time and resolution _succeeds_, it will
+    be logged with the `INFO` level.
+  - When symbol is queried for the first time and resolution _fails_, it will be
+    logged with the `WARN` level.
+  - All subsequent queries (cache hits) will be logged with the `TRACE` level to
+    reduce noise in the logs.
 
 ## [0.2.0] - 2026-04-09
 

--- a/docs/data-provider-development-guide.md
+++ b/docs/data-provider-development-guide.md
@@ -135,9 +135,9 @@ interface SymbolQuery {
 
 **Key points:**
 
-- At least one field will be present (never all empty).
+- At least one field will be non-empty (an all-empty query is rejected before providers are called).
 - All fields are optional - check which ones are available before using.
-- Values may have whitespace and varying case - normalize them (uppercase, trim).
+- `symbol`, `isin`, and `cusip` are always trimmed and uppercased before your method is called; `name` is always trimmed. You do not need to normalize these fields yourself.
 - Company names may be partial or have variations (e.g., "Apple Inc", "Apple, Inc.").
 
 **Common query patterns:**
@@ -166,7 +166,7 @@ return null;
 
 - Return a non-empty string when resolution succeeds (uppercase recommended).
 - Returning `null` allows the system to try other registered providers or fall back to the original value.
-- The `SymbolDataService` tracks which provider returned the result.
+- The `SymbolDataService` tracks which provider returned the result and caches it in memory — your `query()` method is called at most once per unique identifier combination per conversion run.
 
 ## Example
 
@@ -226,7 +226,7 @@ export class JsonFileProvider extends DataProvider {
 
 - **Normalize inputs**: Convert to uppercase and trim whitespace consistently.
 - **Return `null` on failure**: Don't throw errors, return `null` if symbol cannot be resolved.
-- **Cache results**: For external lookups, cache to improve the performance, consider persistent cache to retain data across runs.
+- **Cache data, not queries**: `SymbolDataService` automatically caches resolution results in memory for the duration of the run, so your `query()` method is called at most once per unique identifier combination. However, if your provider loads data from an external source (files, APIs, databases), cache that data internally (as in the `JsonFileProvider` example above) to avoid reloading it on every query call. Consider a persistent cache to retain data across runs for providers that make expensive external lookups.
 - **Use `canHandle()`**: Implement `canHandle()` so that converter can skip your provider when it can't handle specific query types.
 - **Add tests**: Create tests in `tests/data-providers/` to verify your provider.
 

--- a/docs/format-plugin-development-guide.md
+++ b/docs/format-plugin-development-guide.md
@@ -372,7 +372,7 @@ export class MyCustomFormat extends BaseFormat {
 }
 ```
 
-**Note:** If you don't need symbol resolution, you can ignore the `symbolDataService` parameter. You only need it if you want to resolve ISINs, CUSIPs, or company names to symbols. Symbol overrides from the INI file are applied automatically after conversion, so you don't need to handle symbol override logic manually in your format plugin.
+**Note:** If you don't need symbol resolution, you can ignore the `symbolDataService` parameter. You only need it if you want to resolve ISINs, CUSIPs, or company names to symbols. Resolution results are cached in memory by `SymbolDataService` — calling `querySymbolWithFallback()` multiple times with the same query parameters is efficient and will not repeat provider lookups. Symbol overrides from the INI file are applied automatically after conversion, so you don't need to handle symbol override logic manually in your format plugin.
 
 ## Best Practices
 

--- a/docs/technical-information.md
+++ b/docs/technical-information.md
@@ -65,9 +65,15 @@ This document provides technical details about the architecture, design, and imp
 **SymbolDataService** (`src/core/SymbolDataService.ts`)
 
 - Orchestrates symbol resolution across registered data providers.
-- Queries providers in registration order and returns the first match.
-- Falls back to the original identifier when no provider can resolve a symbol.
+- `querySymbol()` follows these steps:
+  1. Normalizes the query: `symbol`, `ISIN`, and `CUSIP` are trimmed and uppercased; `name` is only trimmed. Queries differing only in whitespace or casing are therefore treated as identical.
+  2. Short-circuits when all fields are empty after normalization, returning `{ symbol: "", provider: "Fallback" }` without querying any provider.
+  3. Checks the in-memory cache and returns the cached `SymbolResult` on a hit.
+  4. Queries providers in registration order, caches the first match, and returns it.
+  5. Returns `null` if no provider returns a match.
+- `querySymbolWithFallback()` calls `querySymbol()` and adds a fallback that returns the best available identifier (ISIN -> CUSIP -> sanitized name) when `querySymbol()` returns `null`.
 - Exposes registered provider info for diagnostics and logging.
+- Logs successful resolutions at the `INFO` level, cache hits at the `TRACE` level, and unresolvable identifiers at the `WARN` level.
 
 **DataProvider** (`src/core/DataProvider.ts`)
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -224,6 +224,8 @@ CTW_OVERRIDES="examples/overrides.ini" convert-to-wealthfolio convert examples/s
 
 **Note**: ISIN, CUSIP, and company name lookups are handled by plugins during conversion. Symbol overrides, on the other hand, are done automatically _after_ the conversion. So if you have an ISIN that resolves to a symbol, and that symbol is in the overrides, the override will be applied to the resolved symbol.
 
+**Note**: Symbol resolution results are cached in memory for the duration of the conversion. If the same combination of symbol, ISIN, CUSIP, and company name appears multiple times in the input CSV, the identifier is resolved only once and the result is reused for all matching rows. Cache hits are logged at the `TRACE` level; use `--trace` to see them.
+
 ### List Supported Formats
 
 Use the `list` command to see all available formats that can be passed to the `--format` option:

--- a/src/core/SymbolDataService.ts
+++ b/src/core/SymbolDataService.ts
@@ -12,6 +12,8 @@ import { formatLoggedValue, sanitizeName } from "./Utils";
 // TODO: Should we use "UNKNOWN" or something similar here instead of an empty string?
 const UNKNOWN_SYMBOL = "";
 
+const FALLBACK_PROVIDER_NAME = "Fallback";
+
 /**
  * Result from a symbol query
  */
@@ -27,37 +29,101 @@ export interface SymbolResult {
  */
 export class SymbolDataService {
   private providers: DataProvider[] = [];
+  private resolutionCache: Record<string, SymbolResult> = {};
 
   /**
    * Register a data provider
    *
+   * The provider will be added to the end of the list. If multiple providers can resolve the same
+   * symbol, the first registered provider takes precedence.
+   *
+   * This also clears the resolution cache for the fallback provider to ensure that cached fallback
+   * results are re-evaluated against the new provider. There's no need to clear the cache of other
+   * providers, as new providers are added to the end of the list and will only be used if earlier
+   * providers don't return a result.
+   *
    * @param provider - Data provider instance
    */
   registerProvider(provider: DataProvider): void {
+    this.clearCacheForProvider(FALLBACK_PROVIDER_NAME);
     this.providers.push(provider);
   }
 
   /**
    * Query for a symbol across all registered providers
    *
-   * Tries each provider in order until one returns a result.
+   * Tries each provider in order until one returns a result. The query is normalized before
+   * querying providers: `symbol`, `ISIN`, and `CUSIP` are trimmed and uppercased, while `name` is
+   * only trimmed. Therefore, queries that differ only in whitespace or casing are treated as
+   * identical.
+   *
+   * **Note:** If all query fields end up missing or empty after normalization, providers are not
+   * queried and a result with an empty symbol is returned immediately, as there is no meaningful
+   * way to resolve an empty query.
+   *
+   * **Note:** If a cache hit contains result from the fallback provider, it will be treated as no
+   * result from providers and `null` will be returned immediately. This is because fallback result
+   * means that no provider was able to resolve the query when `querySymbolWithFallback()` was
+   * called previously with the same query, and fallback result was returned.
    *
    * @param query - Symbol query parameters
-   * @returns Symbol result from the first provider that has data, or null
+   * @returns Symbol result from the first provider that has data, or `null` if no provider could resolve the symbol
    */
   querySymbol(query: SymbolQuery): SymbolResult | null {
+    const logger = Logger.getInstance();
+
+    const normalizedQuery = this.normalizeQuery(query);
+    if (
+      !normalizedQuery.symbol &&
+      !normalizedQuery.isin &&
+      !normalizedQuery.cusip &&
+      !normalizedQuery.name
+    ) {
+      logger.warn(
+        `Received a query with ${bold("all fields missing or empty")} -> returning ${bold("empty")} symbol`,
+      );
+      return {
+        symbol: UNKNOWN_SYMBOL,
+        provider: FALLBACK_PROVIDER_NAME,
+      };
+    }
+
+    const formattedQuery = this.formatQueryForLogging(query);
+    const cachedResult = this.getFromCache(normalizedQuery);
+    if (cachedResult) {
+      if (cachedResult.provider === FALLBACK_PROVIDER_NAME) {
+        // Cached result is from the fallback — this means that no provider was able to resolve the
+        // query last time it was attempted, so we can skip querying providers again
+        return null;
+      } else {
+        if (cachedResult.symbol !== query.symbol) {
+          // Log only if the resulting symbol is different from the original query symbol
+          logger.trace(
+            `Using cached result for ${formattedQuery} -> ${bold(cachedResult.symbol)} (provider: ${bold(cachedResult.provider)})`,
+          );
+        }
+
+        return cachedResult;
+      }
+    }
+
     // Try each provider in registration order
     for (const provider of this.providers) {
-      if (!provider.canHandle(query)) {
+      if (!provider.canHandle(normalizedQuery)) {
         continue;
       }
 
-      const symbol = provider.query(query);
+      const symbol = provider.query(normalizedQuery);
       if (symbol) {
-        return {
+        const result = {
           symbol,
           provider: provider.getName(),
         };
+        logger.info(
+          `Resolved ${formattedQuery} -> ${bold(result.symbol)} (provider: ${bold(result.provider)})`,
+        );
+
+        return this.addToCache(normalizedQuery, result);
       }
     }
 
@@ -72,38 +138,43 @@ export class SymbolDataService {
    * @returns Symbol result with fallback to original values, never null
    */
   querySymbolWithFallback(query: SymbolQuery): SymbolResult {
-    const logger = Logger.getInstance();
     const result = this.querySymbol(query);
-
     if (result) {
-      logger.debug(
-        `Resolved ${formatLoggedValue(query.symbol, "symbol ", bold("empty") + " symbol")}${formatLoggedValue(query.isin, ", ISIN: ")}${formatLoggedValue(query.cusip, ", CUSIP: ")}${formatLoggedValue(query.name, ", name: ")} -> ${bold(result.symbol)} (provider: ${bold(result.provider)})`,
-      );
-
       return result;
+    }
+
+    const logger = Logger.getInstance();
+    const normalizedQuery = this.normalizeQuery(query);
+    const formattedQuery = this.formatQueryForLogging(query);
+
+    const cachedResult = this.getFromCache(normalizedQuery);
+    if (cachedResult) {
+      // `querySymbol()` will return `null` for fallback cache entries, so we need to re-check the
+      // cache for a fallback result.
+      logger.trace(
+        `Using cached result for ${formattedQuery} -> ${bold(cachedResult.symbol)} (provider: ${bold(cachedResult.provider)})`,
+      );
+      return cachedResult;
     }
 
     // Fallback: return the symbol based on the original query values in the priority order: symbol,
     // ISIN, CUSIP, sanitized name
-    const symbol = (
-      query.symbol ||
-      query.isin ||
-      query.cusip ||
-      sanitizeName(query.name, UNKNOWN_SYMBOL)
-    )
-      .trim()
-      .toUpperCase();
+    const symbol =
+      normalizedQuery.symbol ||
+      normalizedQuery.isin ||
+      normalizedQuery.cusip ||
+      sanitizeName(normalizedQuery.name, UNKNOWN_SYMBOL);
 
-    if (!query.symbol) {
-      logger.warn(
-        `Couldn't resolve ${bold("empty")} symbol${formatLoggedValue(query.isin, ", ISIN: ")}${formatLoggedValue(query.cusip, ", CUSIP: ")}${formatLoggedValue(query.name, ", name: ")} -> falling back to ${bold(symbol)}`,
-      );
+    // When query has a symbol and resolution doesn't return a result, this only means that there is
+    // no override for that symbol. So we only log when there is no symbol in the query.
+    if (!normalizedQuery.symbol) {
+      logger.warn(`Couldn't resolve ${formattedQuery} -> falling back to ${bold(symbol)}`);
     }
 
-    return {
+    return this.addToCache(normalizedQuery, {
       symbol,
-      provider: "Fallback",
-    };
+      provider: FALLBACK_PROVIDER_NAME,
+    });
   }
 
   /**
@@ -120,8 +191,12 @@ export class SymbolDataService {
 
   /**
    * Clear all providers
+   *
+   * This also clears the resolution cache to ensure that stale results from removed providers are
+   * not returned on subsequent queries.
    */
   clearProviders(): void {
+    this.clearCache();
     this.providers = [];
   }
 
@@ -130,5 +205,90 @@ export class SymbolDataService {
    */
   getProviderCount(): number {
     return this.providers.length;
+  }
+
+  /**
+   * Format a symbol query for logging
+   *
+   * The resulting string includes only non-empty fields with appropriate labels and formatting.
+   *
+   * @param query - Symbol query to format
+   * @returns Formatted string for logging
+   */
+  private formatQueryForLogging(query: SymbolQuery): string {
+    return `${formatLoggedValue(query.symbol, "symbol ", bold("empty") + " symbol")}${formatLoggedValue(query.isin, ", ISIN: ")}${formatLoggedValue(query.cusip, ", CUSIP: ")}${formatLoggedValue(query.name, ", name: ")}`;
+  }
+
+  /**
+   * Normalize a symbol query by trimming whitespace and uppercasing identifiers
+   *
+   * `symbol`, `isin`, and `cusip` are trimmed and uppercased; `name` is only trimmed. This ensures
+   * that queries that differ only in whitespace or casing are treated as identical for caching and
+   * provider querying purposes.
+   */
+  private normalizeQuery(query: SymbolQuery): SymbolQuery {
+    return {
+      symbol: query.symbol?.trim().toUpperCase(),
+      isin: query.isin?.trim().toUpperCase(),
+      cusip: query.cusip?.trim().toUpperCase(),
+      name: query.name?.trim(),
+    };
+  }
+
+  /**
+   * Add a resolved symbol result to the cache for a given query
+   *
+   * Pass a normalized query to ensure consistent caching. This ensures that subsequent queries that
+   * differ only in whitespace or casing will hit the same cache entry.
+   *
+   * @param query - Symbol query, preferably normalized
+   * @param result - Symbol result to cache
+   * @returns `query` that was passed as an argument (for method chaining)
+   */
+  private addToCache(query: SymbolQuery, result: SymbolResult): SymbolResult {
+    const cacheKey = JSON.stringify(query);
+    // Store a copy to prevent external mutations from affecting the cache
+    this.resolutionCache[cacheKey] = { ...result };
+    return result;
+  }
+
+  /**
+   * Retrieve a symbol result from the cache for a given query
+   *
+   * Pass a normalized query to ensure consistent cache retrieval. This ensures that queries that
+   * differ only in whitespace or casing will hit the same cache entry.
+   *
+   * @param query - Symbol query, preferably normalized
+   * @returns Cached symbol result if found, or `undefined` if not in cache
+   */
+  private getFromCache(query: SymbolQuery): SymbolResult | undefined {
+    const cacheKey = JSON.stringify(query);
+    const result = this.resolutionCache[cacheKey];
+    // Return a copy to prevent external mutations from affecting the cache
+    return result ? { ...result } : undefined;
+  }
+
+  /**
+   * Clear the whole resolution cache
+   */
+  private clearCache(): void {
+    this.resolutionCache = {};
+  }
+
+  /**
+   * Clear only results from a specific provider in the resolution cache
+   *
+   * This is useful when a provider is removed, to ensure that stale results from that provider are
+   * not returned on subsequent queries without clearing the entire cache and losing results from
+   * other providers.
+   *
+   * @param providerName - Name of the provider whose cached results should be cleared
+   */
+  private clearCacheForProvider(providerName: string): void {
+    for (const key in this.resolutionCache) {
+      if (this.resolutionCache[key].provider === providerName) {
+        delete this.resolutionCache[key];
+      }
+    }
   }
 }

--- a/tests/core/SymbolDataService.test.ts
+++ b/tests/core/SymbolDataService.test.ts
@@ -4,9 +4,10 @@
  */
 
 import { DataProvider, SymbolQuery } from "../../src/core/DataProvider";
-import { Logger, LogLevel } from "../../src/core/Logger";
 import { SymbolDataService } from "../../src/core/SymbolDataService";
 
+// Silence logging during tests
+import { Logger, LogLevel } from "../../src/core/Logger";
 Logger.setLogLevel(LogLevel.ERROR);
 
 class TestProvider extends DataProvider {
@@ -151,31 +152,117 @@ describe("SymbolDataService", () => {
   it("should return empty fallback symbol when query contains no usable fields", () => {
     service.registerProvider(new TestProvider("ProviderA", () => null));
 
-    const result = service.querySymbolWithFallback({});
+    const result = service.querySymbol({});
 
     expect(result).toEqual({ symbol: "", provider: "Fallback" });
   });
 
-  it("should log debug with empty symbol marker when `query.symbol` is missing but provider resolves", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => "AAPL.RESOLVED"));
+  it("should call provider only once for repeated identical queries", () => {
+    const resolver = jest.fn(() => "AAPL");
+    service.registerProvider(new TestProvider("ProviderA", resolver));
 
-    const result = service.querySymbolWithFallback({
-      isin: "US0378331005",
-    });
+    service.querySymbol({ isin: "US0378331005" });
+    service.querySymbol({ isin: "US0378331005" });
+    service.querySymbolWithFallback({ isin: "US0378331005", cusip: "037833100" });
+    service.querySymbol({ isin: "US0378331005" });
 
-    expect(result).toEqual({ symbol: "AAPL.RESOLVED", provider: "ProviderA" });
+    expect(resolver).toHaveBeenCalledTimes(2);
   });
 
-  it("should include all query fields in debug message when they are present", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => "RESOLVED"));
+  it("should treat queries with different whitespace and casing as identical", () => {
+    const resolver = jest.fn(() => "AAPL");
+    service.registerProvider(new TestProvider("ProviderA", resolver));
 
-    const result = service.querySymbolWithFallback({
-      symbol: "AAPL",
-      isin: "US0378331005",
-      cusip: "037833100",
-      name: "Apple Inc",
+    service.querySymbolWithFallback({ symbol: "  aapl  " });
+    service.querySymbolWithFallback({ symbol: "AAPL" });
+    service.querySymbol({ symbol: "aapl" });
+
+    expect(resolver).toHaveBeenCalledTimes(1);
+  });
+
+  it("should re-evaluate fallback cache entries after a new provider is registered", () => {
+    // First provider cannot resolve — result is cached as Fallback
+    service.registerProvider(new TestProvider("ProviderA", () => null));
+    expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
+      symbol: "US0378331005",
+      provider: "Fallback",
     });
 
-    expect(result).toEqual({ symbol: "RESOLVED", provider: "ProviderA" });
+    // Register a second provider that can resolve
+    const resolverB = jest.fn(() => "AAPL");
+    service.registerProvider(new TestProvider("ProviderB", resolverB));
+
+    // The fallback cache entry must have been cleared — ProviderB should now be queried
+    expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
+      symbol: "AAPL",
+      provider: "ProviderB",
+    });
+    expect(resolverB).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not evict non-fallback cache entries when a new provider is registered", () => {
+    // ProviderA resolves the query — result is cached as ProviderA
+    const resolverA = jest.fn(() => "AAPL");
+    service.registerProvider(new TestProvider("ProviderA", resolverA));
+    service.querySymbolWithFallback({ isin: "US0378331005" });
+    expect(resolverA).toHaveBeenCalledTimes(1);
+
+    // Register a second provider
+    const resolverB = jest.fn(() => "MSFT");
+    service.registerProvider(new TestProvider("ProviderB", resolverB));
+    expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
+      symbol: "AAPL",
+      provider: "ProviderA",
+    });
+
+    // Still only one call from the first query
+    expect(resolverA).toHaveBeenCalledTimes(1);
+    expect(resolverB).not.toHaveBeenCalled();
+  });
+
+  it("should clear the entire cache when all providers are cleared", () => {
+    // ProviderA resolves and the result gets cached
+    const resolverA = jest.fn(() => "AAPL");
+    service.registerProvider(new TestProvider("ProviderA", resolverA));
+    service.querySymbol({ isin: "US0378331005" });
+    expect(resolverA).toHaveBeenCalledTimes(1);
+
+    // Clearing providers must also wipe the cache
+    service.clearProviders();
+
+    // Register a new provider and re-query — new provider must be called
+    const resolverB = jest.fn(() => "MSFT");
+    service.registerProvider(new TestProvider("ProviderB", resolverB));
+    expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
+      symbol: "MSFT",
+      provider: "ProviderB",
+    });
+    expect(resolverB).toHaveBeenCalledTimes(1);
+  });
+
+  it("should return `null` from `querySymbol()` without querying providers when a Fallback cache entry exists", () => {
+    // Provider cannot resolve — result is cached as Fallback
+    const resolver = jest.fn(() => null);
+    service.registerProvider(new TestProvider("ProviderA", resolver));
+    service.querySymbolWithFallback({ isin: "US0378331005" });
+    expect(resolver).toHaveBeenCalledTimes(1);
+
+    // Direct querySymbol() should hit the Fallback cache entry and return null immediately
+    const result = service.querySymbol({ isin: "US0378331005" });
+
+    expect(result).toBeNull();
+    // Still only one call from the first query
+    expect(resolver).toHaveBeenCalledTimes(1);
+
+    // querySymbolWithFallback(), on the other hand, should hit the Fallback cache entry and return
+    // the result
+    const resultWithFallback = service.querySymbolWithFallback({ isin: "US0378331005" });
+
+    expect(resultWithFallback).toEqual({
+      symbol: "US0378331005",
+      provider: "Fallback",
+    });
+    // Still only one call from the first query
+    expect(resolver).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Description

Once a symbol is resolved for a given combination of symbol, ISIN, CUSIP, and company name, it will be cached in memory for the duration of the converter's execution. This means that if the same symbol appears multiple times in the input CSV, it will only be resolved once, and all subsequent occurrences will use the cached value. The cache is based on the combination of symbol, ISIN, CUSIP, and company name, which means that if one query contains only ISIN and another query contains a combination of ISIN and CUSIP, there will be two separate cache entries.

As a consequence, `INFO` and `WARNING` log level resolution messages will be loged once per unique combination of symbol, ISIN, CUSIP, and company name. All subsequent queries will be logged as cache hits with the `TRACE` log level to reduce noise in the logs.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New format plugin (adds support for a new CSV format)
- [ ] New data provider (adds support for a new data source for looking up symbols, etc.)
- [x] Improvement or enhancement to existing functionality (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (project maintenance, build configuration, etc.)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CODE_OF_CONDUCT.md) and agree to abide by it
- [x] I agree that my contributions will be licensed under the **BSD 3-Clause License**
- [x] My code follows the project's [coding style and conventions](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md#contributing)
- ~~[ ] I have added [JSDoc](https://jsdoc.app/) documentation for any new functions, classes, or methods~~
- [x] I have updated relevant documentation (README, ChangeLog, docs/, etc.)
- [x] I have written tests for my changes
- [x] All new code has adequate test coverage
- [x] All existing tests pass locally
- [x] My commits have clear and descriptive commit messages
- [x] My commits are atomic, i.e. complete and self-contained units of change (else, meld the commits before submitting the PR)

---

By submitting this pull request, I confirm that I have read and understood the [contribution guidelines](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md) and that my contributions are my own work.
