### PR TITLE
Add support for ISIN column in the output CSV

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,9 @@ Upcoming release.
     the input CSV into the `isin` column of the output CSV, in addition to using
     it for symbol resolution. If not present or empty, the `ISIN` column will be
     converted to an empty value in the output CSV.
+  - Symbol resolution providers can now also resolve ISINs and return them as
+    part of the symbol resolution result. ISIN can be returned together with the
+    symbol or on its own if the symbol cannot be resolved.
 
 - **Symbol resolution caching** - once a symbol is resolved, it will be cached
   in-memory for the duration of the converter's execution. This means that if
@@ -49,6 +52,12 @@ Upcoming release.
   CLI options take precedence over environment variables when both are set.
 
 ### Changed
+
+- **Fallback symbol resolution** - The fallback for symbol resolution will no
+  longer copy ISIN value from the query into the symbol field when symbol cannot
+  be resolved. Instead, it will return the ISIN and leave the symbol unset. The
+  output CSV will then contain the ISIN value in the `isin` column and an empty
+  value in the `symbol` column.
 
 - **Symbol normalization** - before querying providers or looking up the cache,
   the converter now normalizes query fields: symbol, ISIN, and CUSIP are trimmed

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,23 @@ Upcoming release.
     part of the symbol resolution result. ISIN can be returned together with the
     symbol or on its own if the symbol cannot be resolved.
 
+- **ISIN overrides and mapping** - the overrides INI file can now also contain
+  ISIN overrides and mapping sections, which allow you to override ISIN values
+  and map symbols, CUSIPs, and company names to ISINs. This allows you to
+  provide a custom ISIN for a transaction that has an incorrect or missing ISIN
+  in the input CSV. The following sections were added:
+  - `[ISIN.ISIN]` - contains ISIN overrides;
+  - `[ISIN.Symbol]` - maps symbols to ISINs;
+  - `[ISIN.CUSIP]` - maps CUSIPs to ISINs;
+  - `[ISIN.Name]` - maps company names to ISINs.
+
+  ISIN lookups are performed before symbol lookups, which means that symbol
+  lookups are performed with an already resolved ISIN.
+
+  **Note:** The names of the symbol mapping sections were also renamed to be
+  consistent with ISIN section naming, see the breaking change in the
+  **Changed** section below for more details.
+
 - **Symbol resolution caching** - once a symbol is resolved, it will be cached
   in-memory for the duration of the converter's execution. This means that if
   the same symbol appears multiple times in the input CSV, it will only be
@@ -52,6 +69,18 @@ Upcoming release.
   CLI options take precedence over environment variables when both are set.
 
 ### Changed
+
+- **BREAKING**: **Overrides INI file format** - The flat top-level sections
+  (`[Symbol]`, `[ISIN]`, `[CUSIP]`, `[Name]`) are no longer supported. They are
+  replaced by nested sections that explicitly declare both the output type and
+  the key type:
+
+  | Old section | New section       | Meaning                       |
+  | ----------- | ----------------- | ----------------------------- |
+  | `[Symbol]`  | `[Symbol.Symbol]` | Contains symbol overrides     |
+  | `[ISIN]`    | `[Symbol.ISIN]`   | Maps ISINs to symbols         |
+  | `[CUSIP]`   | `[Symbol.CUSIP]`  | Maps CUSIPs to symbols        |
+  | `[Name]`    | `[Symbol.Name]`   | Maps company names to symbols |
 
 - **Fallback symbol resolution** - The fallback for symbol resolution will no
   longer copy ISIN value from the query into the symbol field when symbol cannot

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,14 @@ Upcoming release.
 
 ### Added
 
+- **Support for ISIN field** (was added to **Wealthfolio** in v3.2.0):
+  - The converter now supports an `isin` field in the output CSV, which can be
+    used to provide ISIN as an alternative or a supplement to a ticker symbol.
+  - The Generic format plugin has been updated to copy the `ISIN` column from
+    the input CSV into the `isin` column of the output CSV, in addition to using
+    it for symbol resolution. If not present or empty, the `ISIN` column will be
+    converted to an empty value in the output CSV.
+
 - **Symbol resolution caching** - once a symbol is resolved, it will be cached
   in-memory for the duration of the converter's execution. This means that if
   the same symbol appears multiple times in the input CSV, it will only be

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SPDX-License-Identifier: BSD-3-Clause
 - **Format Detection**: Automatically detects input format.
 - **Field Validation**: Validates all output records against activity type-specific field requirements.
 - **Symbol Resolution**: Supports pluggable data providers for symbol, ISIN, CUSIP, and company name lookups.
-- **Symbol Override and Mapping**: Allows overriding symbols and mapping them from ISINs, CUSIPs, and company names using an INI file.
+- **Symbol and ISIN Override and Mapping**: Allows using an INI file to override symbols and ISINs; map symbols from ISINs, CUSIPs, and company names; map ISINs from symbols, CUSIPs, and company names.
 - **Advanced Logging**: Colorized log output with configurable log verbosity levels.
 - **Comprehensive Testing**: Full test coverage to ensure reliability.
 - **Minimal Dependencies**: Only uses lean libraries as runtime dependencies with none or minimal transitive dependencies.

--- a/docs/data-provider-development-guide.md
+++ b/docs/data-provider-development-guide.md
@@ -75,7 +75,12 @@ export class MyCustomProvider extends DataProvider {
 Add your provider to `src/data-providers/index.ts`:
 
 ```typescript
-export { Overrides, OverridesDataProvider, parseOverridesFile } from "./OverridesDataProvider";
+export {
+  Overrides,
+  OverridesByType,
+  OverridesDataProvider,
+  parseOverridesFile,
+} from "./OverridesDataProvider";
 export { MyCustomProvider } from "./MyCustomProvider";
 ```
 
@@ -137,7 +142,7 @@ interface SymbolQuery {
 
 - At least one field will be non-empty (an all-empty query is rejected before providers are called).
 - All fields are optional - check which ones are available before using.
-- `symbol`, `isin`, and `cusip` are always trimmed and uppercased before your method is called; `name` is always trimmed. You do not need to normalize these fields yourself.
+- `symbol`, `isin`, and `cusip` are always trimmed and uppercased before your method is called; `name` is always trimmed. Returned `symbol` and `isin` values are also trimmed and uppercased automatically. You do not need to normalize these fields yourself, but it's still a good practice to already return them in a normalized form.
 - Company names may be partial or have variations (e.g., "Apple Inc", "Apple, Inc.").
 
 **Common query patterns:**
@@ -178,9 +183,9 @@ return {};
 
 **Important details:**
 
-- Set `symbol` when you have resolved a ticker (uppercase recommended), `isin` when you have resolved an ISIN, or both when you have resolved both. At least one field must be set for the result to be considered a successful resolution.
+- Set `symbol` when you have resolved a ticker, `isin` when you have resolved an ISIN, or both when you have resolved both. At least one field must be set for the result to be considered a successful resolution.
 - Only set a field when your provider has resolved a value that _differs_ from the corresponding query field. Do not echo `query.symbol` or `query.isin` back — it adds no information and the `SymbolDataService` will strip them anyway.
-- Returning `{}` (empty object) allows the system to try other registered providers or fall back to the original value.
+- Returning empty `SymbolResult` (`{}`) allows the system to try other registered providers or fall back to the original value.
 - The `SymbolDataService` tracks which provider returned the result and caches it in memory — your `query()` method is called at most once per unique identifier combination per conversion run.
 
 ## Example
@@ -219,14 +224,14 @@ export class JsonFileProvider extends DataProvider {
 
   query(query: SymbolQuery): SymbolResult {
     if (query.isin) {
-      const symbol = this.cache.get(`ISIN:${query.isin.toUpperCase()}`);
+      const symbol = this.cache.get(`ISIN:${query.isin}`);
       if (symbol) {
         return { symbol };
       }
     }
 
     if (query.cusip) {
-      const symbol = this.cache.get(`CUSIP:${query.cusip.toUpperCase()}`);
+      const symbol = this.cache.get(`CUSIP:${query.cusip}`);
       if (symbol) {
         return { symbol };
       }
@@ -239,7 +244,7 @@ export class JsonFileProvider extends DataProvider {
 
 ## Best Practices
 
-- **Return empty object on failure**: Don't throw errors, return `{}` (empty object) if symbol cannot be resolved.
+- **Return empty object on failure**: Don't throw errors, return empty `SymbolResult` (`{}`) if symbol cannot be resolved.
 - **Do not echo query values back as resolution results**: Don't simply copy `query.symbol` or `query.isin` to their respective fields in the result without actual resolution. `SymbolDataService` strips any result field that is identical to the corresponding query field and treats a result with no remaining fields as "no resolution", then continues to the next provider. Only set a field when you have genuinely resolved or enriched it from a data source.
 - **Cache data, not queries**: `SymbolDataService` automatically caches resolution results in memory for the duration of the run, so your `query()` method is called at most once per unique identifier combination. However, if your provider loads data from an external source (files, APIs, databases), cache that data internally (as in the `JsonFileProvider` example above) to avoid reloading it on every query call. Consider a persistent cache to retain data across runs for providers that make expensive external lookups.
 - **Use `canHandle()`**: Implement `canHandle()` so that converter can skip your provider when it can't handle specific query types.

--- a/docs/data-provider-development-guide.md
+++ b/docs/data-provider-development-guide.md
@@ -17,7 +17,7 @@ Example: `src/data-providers/MyCustomProvider.ts`
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { DataProvider, SymbolQuery } from "../core/DataProvider";
+import { DataProvider, SymbolQuery, SymbolResult } from "../core/DataProvider";
 
 export class MyCustomProvider extends DataProvider {
   constructor() {
@@ -28,26 +28,26 @@ export class MyCustomProvider extends DataProvider {
    * Resolve a symbol from a query
    *
    * @param query - Contains optional: symbol, isin, cusip, name
-   * @returns Resolved symbol string if found, `null` otherwise
+   * @returns Resolved symbol result or empty object if cannot resolve
    */
-  query(query: SymbolQuery): string | null {
+  query(query: SymbolQuery): SymbolResult {
     // Try different resolution strategies
     if (query.isin) {
       const symbol = this.lookupIsin(query.isin);
       if (symbol) {
-        return symbol;
+        return { symbol };
       }
     }
 
     if (query.cusip) {
       const symbol = this.lookupCusip(query.cusip);
       if (symbol) {
-        return symbol;
+        return { symbol };
       }
     }
 
     // Not found
-    return null;
+    return {};
   }
 
   /**
@@ -58,14 +58,14 @@ export class MyCustomProvider extends DataProvider {
     return query.isin !== undefined || query.cusip !== undefined;
   }
 
-  private lookupIsin(isin: string): string | null {
+  private lookupIsin(isin: string): string | undefined {
     // Your lookup logic here
-    return null;
+    return undefined;
   }
 
-  private lookupCusip(cusip: string): string | null {
+  private lookupCusip(cusip: string): string | undefined {
     // Your lookup logic here
-    return null;
+    return undefined;
   }
 }
 ```
@@ -106,7 +106,7 @@ And register it inside the `convert()` method:
   }
 ```
 
-Now, whenever a symbol query is made by the format plugin, your provider will be called in the order it was registered. If your provider returns `null`, the system will continue to the next provider until a match is found or all providers are exhausted.
+Now, whenever a symbol query is made by the format plugin, your provider will be called in the order it was registered. If your provider returns an empty object (`{}`), the system will continue to the next provider until a match is found or all providers are exhausted.
 
 ## 3. Build and test
 
@@ -150,22 +150,37 @@ interface SymbolQuery {
 
 ### Return Value
 
-Return a resolved symbol string when your provider finds a match:
+Return a `SymbolResult` object. Use `symbol` to provide a resolved ticker symbol and `isin` to carry a newly resolved ISIN code.
+
+When your provider finds a match by symbol:
 
 ```typescript
-return "AAPL";
+return { symbol: "AAPL" };
 ```
 
-Return `null`, **not** an empty string, when your provider cannot resolve the symbol:
+When your provider resolves an ISIN but cannot determine a ticker symbol:
 
 ```typescript
-return null;
+return { isin: "US0378331005" };
+```
+
+When your provider resolves both symbol and ISIN:
+
+```typescript
+return { symbol: "AAPL", isin: "US0378331005" };
+```
+
+When your provider cannot resolve anything, return an empty object:
+
+```typescript
+return {};
 ```
 
 **Important details:**
 
-- Return a non-empty string when resolution succeeds (uppercase recommended).
-- Returning `null` allows the system to try other registered providers or fall back to the original value.
+- Set `symbol` when you have resolved a ticker (uppercase recommended), `isin` when you have resolved an ISIN, or both when you have resolved both. At least one field must be set for the result to be considered a successful resolution.
+- Only set a field when your provider has resolved a value that _differs_ from the corresponding query field. Do not echo `query.symbol` or `query.isin` back — it adds no information and the `SymbolDataService` will strip them anyway.
+- Returning `{}` (empty object) allows the system to try other registered providers or fall back to the original value.
 - The `SymbolDataService` tracks which provider returned the result and caches it in memory — your `query()` method is called at most once per unique identifier combination per conversion run.
 
 ## Example
@@ -176,7 +191,7 @@ File-based Provider that loads symbol mappings from a JSON file specified by the
 import fs from "fs";
 import path from "path";
 
-import { DataProvider, SymbolQuery } from "../core/DataProvider";
+import { DataProvider, SymbolQuery, SymbolResult } from "../core/DataProvider";
 
 export class JsonFileProvider extends DataProvider {
   private cache = new Map<string, string>();
@@ -202,30 +217,30 @@ export class JsonFileProvider extends DataProvider {
     }
   }
 
-  query(query: SymbolQuery): string | null {
+  query(query: SymbolQuery): SymbolResult {
     if (query.isin) {
       const symbol = this.cache.get(`ISIN:${query.isin.toUpperCase()}`);
       if (symbol) {
-        return symbol;
+        return { symbol };
       }
     }
 
     if (query.cusip) {
       const symbol = this.cache.get(`CUSIP:${query.cusip.toUpperCase()}`);
       if (symbol) {
-        return symbol;
+        return { symbol };
       }
     }
 
-    return null;
+    return {};
   }
 }
 ```
 
 ## Best Practices
 
-- **Normalize inputs**: Convert to uppercase and trim whitespace consistently.
-- **Return `null` on failure**: Don't throw errors, return `null` if symbol cannot be resolved.
+- **Return empty object on failure**: Don't throw errors, return `{}` (empty object) if symbol cannot be resolved.
+- **Do not echo query values back as resolution results**: Don't simply copy `query.symbol` or `query.isin` to their respective fields in the result without actual resolution. `SymbolDataService` strips any result field that is identical to the corresponding query field and treats a result with no remaining fields as "no resolution", then continues to the next provider. Only set a field when you have genuinely resolved or enriched it from a data source.
 - **Cache data, not queries**: `SymbolDataService` automatically caches resolution results in memory for the duration of the run, so your `query()` method is called at most once per unique identifier combination. However, if your provider loads data from an external source (files, APIs, databases), cache that data internally (as in the `JsonFileProvider` example above) to avoid reloading it on every query call. Consider a persistent cache to retain data across runs for providers that make expensive external lookups.
 - **Use `canHandle()`**: Implement `canHandle()` so that converter can skip your provider when it can't handle specific query types.
 - **Add tests**: Create tests in `tests/data-providers/` to verify your provider.

--- a/docs/format-plugin-development-guide.md
+++ b/docs/format-plugin-development-guide.md
@@ -52,20 +52,27 @@ export class MyCustomFormat extends BaseFormat {
     // define a more convenient data structure and convert to it by overriding `getParseOptions()`.
     return records.map((record) => {
       let symbol = record.ticker?.trim().toUpperCase() ?? "";
+      let isin = record.isin?.trim().toUpperCase() ?? "";
       // If symbol is empty, try to resolve it from other fields using the symbol data service
       if (!symbol && (record.isin || record.cusip || record.securityName)) {
-        ({ symbol } = symbolDataService.querySymbolWithFallback({
+        const resolved = symbolDataService.querySymbolWithFallback({
           isin: record.isin,
           cusip: record.cusip,
           name: record.securityName,
-        }));
+        });
+        if (resolved.symbol) {
+          symbol = resolved.symbol;
+        }
+        if (resolved.isin) {
+          isin = resolved.isin;
+        }
       }
 
       return {
         date: new Date(record.date),
         instrumentType: this.mapInstrumentType(record.instrumentType),
         symbol,
-        isin: record.isin?.trim().toUpperCase() ?? "",
+        isin,
         quantity: Math.abs(parseFloat(record.shares)),
         activityType: this.mapActivityType(record.action),
         unitPrice: Math.abs(parseFloat(record.price)),
@@ -344,21 +351,28 @@ export class MyCustomFormat extends BaseFormat {
   ): WealthfolioRecord[] {
     return records.map((record) => {
       let symbol = record.symbol || "";
+      let isin = record.isin || "";
       // When symbol is empty, use `symbolDataService` to resolve one. It handles ISIN, CUSIP, or
       // company name lookups, and fallbacks.
       if (!symbol && (record.isin || record.cusip || record.name)) {
-        ({ symbol } = symbolDataService.querySymbolWithFallback({
+        const resolved = symbolDataService.querySymbolWithFallback({
           isin: record.isin,
           cusip: record.cusip,
           name: record.name,
-        }));
+        });
+        if (resolved.symbol) {
+          symbol = resolved.symbol;
+        }
+        if (resolved.isin) {
+          isin = resolved.isin;
+        }
       }
 
       return {
         date: new Date(record.date),
         instrumentType: InstrumentType.Unknown,
         symbol, // Already resolved with overrides applied
-        isin: record.isin || "",
+        isin,
         quantity: parseFloat(record.shares),
         activityType: this.mapActivityType(record.action),
         unitPrice: parseFloat(record.unitPrice),

--- a/docs/format-plugin-development-guide.md
+++ b/docs/format-plugin-development-guide.md
@@ -51,7 +51,7 @@ export class MyCustomFormat extends BaseFormat {
     // Note: All CSV values are strings - convert types as needed during processing. You can also
     // define a more convenient data structure and convert to it by overriding `getParseOptions()`.
     return records.map((record) => {
-      let symbol = (record.ticker || "").trim().toUpperCase();
+      let symbol = record.ticker?.trim().toUpperCase() ?? "";
       // If symbol is empty, try to resolve it from other fields using the symbol data service
       if (!symbol && (record.isin || record.cusip || record.securityName)) {
         ({ symbol } = symbolDataService.querySymbolWithFallback({
@@ -65,6 +65,7 @@ export class MyCustomFormat extends BaseFormat {
         date: new Date(record.date),
         instrumentType: this.mapInstrumentType(record.instrumentType),
         symbol,
+        isin: record.isin?.trim().toUpperCase() ?? "",
         quantity: Math.abs(parseFloat(record.shares)),
         activityType: this.mapActivityType(record.action),
         unitPrice: Math.abs(parseFloat(record.price)),
@@ -237,6 +238,7 @@ interface WealthfolioRecord {
   date: Date; // Transaction date as Date object
   instrumentType: InstrumentType; // Instrument category enum (optional by activity)
   symbol: string; // Asset symbol / ticker (uppercase)
+  isin: string; // ISIN code (optional, can substitute symbol for asset transactions)
   quantity: number; // Number of shares / units
   activityType: ActivityType; // Transaction type enum
   unitPrice: number; // Unit price
@@ -356,6 +358,7 @@ export class MyCustomFormat extends BaseFormat {
         date: new Date(record.date),
         instrumentType: InstrumentType.Unknown,
         symbol, // Already resolved with overrides applied
+        isin: record.isin || "",
         quantity: parseFloat(record.shares),
         activityType: this.mapActivityType(record.action),
         unitPrice: parseFloat(record.unitPrice),

--- a/docs/format-plugin-development-guide.md
+++ b/docs/format-plugin-development-guide.md
@@ -333,7 +333,7 @@ As a plugin developer, you should:
 
 The validation happens automatically after your `convert()` method returns the records, so you can trust that only valid records will be written to the output file.
 
-## Symbol Overrides and Identifier Resolution
+## Symbol and ISIN Overrides and Resolution
 
 Your plugin can use the `SymbolDataService` passed to the `convert()` method to resolve ISINs, CUSIPs, and company names. This automatically applies user-provided mapping from INI file and enables custom data providers.
 
@@ -389,7 +389,7 @@ export class MyCustomFormat extends BaseFormat {
 }
 ```
 
-**Note:** If you don't need symbol resolution, you can ignore the `symbolDataService` parameter. You only need it if you want to resolve ISINs, CUSIPs, or company names to symbols. Resolution results are cached in memory by `SymbolDataService` — calling `querySymbolWithFallback()` multiple times with the same query parameters is efficient and will not repeat provider lookups. Symbol overrides from the INI file are applied automatically after conversion, so you don't need to handle symbol override logic manually in your format plugin.
+**Note:** If you don't need symbol resolution, you can ignore the `symbolDataService` parameter. You only need it if you want to resolve ISINs, CUSIPs, or company names to symbols. Resolution results are cached in memory by `SymbolDataService` — calling `querySymbolWithFallback()` multiple times with the same query parameters is efficient and will not repeat provider lookups. Symbol and ISIN overrides from the INI file are applied automatically after conversion, so you don't need to handle symbol override logic manually in your format plugin.
 
 ## Best Practices
 
@@ -398,7 +398,7 @@ export class MyCustomFormat extends BaseFormat {
 - **Type conversion**: Convert string values to appropriate types (numbers, dates, etc.) during parsing (see [Customizing CSV parse options](#customizing-csv-parse-options)).
 - **Format detection**: Make your `validate()` method robust to detect only your CSV format. In other words, try to avoid false positives for other formats.
 - **Default currency**: If your format doesn't include a currency column, use the `defaultCurrency` parameter provided to `convert()` method.
-- **Symbol Resolution**: Use `symbolDataService.querySymbol()` or `symbolDataService.querySymbolWithFallback()` to resolve symbols from ISIN, CUSIP, and company name fields (see [Symbol Overrides and Identifier Resolution](#symbol-overrides-and-identifier-resolution)).
+- **Symbol and ISIN Resolution**: Use `symbolDataService.querySymbol()` or `symbolDataService.querySymbolWithFallback()` to resolve symbols and ISINs from ISIN, CUSIP, and company name fields (see [Symbol and ISIN Overrides and Resolution](#symbol-and-isin-overrides-and-resolution)).
 - **Error handling**: Provide clear error messages for invalid input.
 - **Documentation**: Document your format requirements and any assumptions.
 - **Testing**: Test with sample CSV files before submitting.

--- a/docs/generic-format-user-guide.md
+++ b/docs/generic-format-user-guide.md
@@ -17,6 +17,7 @@ This format supports standard transaction types such as buys, sells, dividends, 
 
 - [CSV Structure](#csv-structure)
   - [Required Columns](#required-columns)
+  - [Conditionally Required Columns](#conditionally-required-columns)
   - [Optional Columns](#optional-columns)
   - [Column Ordering](#column-ordering)
   - [Header Row](#header-row)
@@ -46,7 +47,7 @@ This format supports standard transaction types such as buys, sells, dividends, 
   - [Missing Required Columns](#missing-required-columns)
   - [Unknown Transaction Type](#unknown-transaction-type)
   - [Invalid Date Format](#invalid-date-format)
-  - [Symbol Required](#symbol-required)
+  - [Symbol or ISIN Required](#symbol-or-isin-required)
 - [Getting Format Information](#getting-format-information)
 - [See Also](#see-also)
 
@@ -60,9 +61,21 @@ The following columns **must** be present in your CSV file:
 | --- | --- | --- |
 | `Date` | Transaction date and, optionally, time (see [Date and Time](#date-and-time) below) | `2024-03-10 13:25:10`, `2024-01-15` |
 | `TransactionType` | Type of transaction (see [Transaction Types](#transaction-types) below) | `BUY`, `SELL`, `DIVIDEND` |
-| `Symbol` | Ticker symbol (empty for cash transactions) | `AAPL`, `MSFT`, `GOOGL` |
 | `Quantity` | Number of shares / units (see [Quantities and Prices](#quantities-and-prices) below) | `100`, `50.5` |
 | `UnitPrice` | Price per share / unit (see [Quantities and Prices](#quantities-and-prices) below) | `150.25`, `1380.50` |
+
+### Conditionally Required Columns
+
+At least one of these columns **must** be present in the CSV file:
+
+| Column | Description | Example |
+| --- | --- | --- |
+| `Symbol` | Ticker symbol | `AAPL`, `MSFT`, `GOOGL` |
+| `ISIN` | International Securities Identification Number | `US0378331005`, `US5949181045` |
+| `CUSIP` | Committee on Uniform Securities Identification Procedures | `037833100`, `594918104` |
+| `CompanyName` | Company name | `Apple Inc.`, `Microsoft Corporation` |
+
+If only `CUSIP` or `CompanyName` is provided, the converter will attempt to resolve the symbol and ISIN using registered data providers. If no data provider can resolve them, the converter will synthesize a symbol by using the best available identifier in the order: CUSIP -> sanitized company name -> no symbol (empty string).
 
 ### Optional Columns
 
@@ -386,7 +399,7 @@ Ensure every row has values for:
 
 - Date
 - TransactionType
-- Symbol (except for cash-only transactions)
+- Symbol, ISIN, or other identifiers from which symbol or ISIN can be resolved (except for cash-only transactions)
 - Quantity
 - UnitPrice
 
@@ -455,7 +468,7 @@ If you need more details for troubleshooting, increase log verbosity by setting 
 
 **Error:** Validation fails with missing column error.
 
-**Solution:** Ensure your CSV has all required columns: `Date`, `TransactionType`, `Symbol`, `Quantity`, and `UnitPrice`.
+**Solution:** Ensure your CSV has all required columns: `Date`, `TransactionType`, `Quantity`, and `UnitPrice`; as well as at least one of `Symbol`, `ISIN`, `CUSIP`, or `CompanyName`. Check for typos in column names and verify that the header row is correctly formatted.
 
 ### Unknown Transaction Type
 
@@ -469,7 +482,7 @@ If you need more details for troubleshooting, increase log verbosity by setting 
 
 **Solution:** See the [Date and Time](#date-and-time) section with recommendations on how to avoid ambiguity.
 
-### Symbol Required
+### Symbol or ISIN Required
 
 Some transaction types require either a ticker symbol or an ISIN:
 
@@ -477,7 +490,7 @@ Some transaction types require either a ticker symbol or an ISIN:
 - `TRANSFER_IN`, `TRANSFER_OUT`, `INTEREST`: Required for asset transactions.
 - `DEPOSIT`, `WITHDRAWAL`, `FEE`, `TAX`, `CREDIT`: Not required.
 
-**Note:** Symbol can also be resolved from ISIN, CUSIP, or company name using an override file. If you provide an ISIN that is mapped to a symbol, both the resolved symbol and the original ISIN will be included in the output CSV.
+**Note:** Symbols and ISINs can also be resolved from other identifiers using an override file. See [Override and Resolve Symbols and ISINs](./user-manual.md#override-and-resolve-symbols-and-isins) for information on how to set up symbol overrides.
 
 ## Getting Format Information
 

--- a/docs/generic-format-user-guide.md
+++ b/docs/generic-format-user-guide.md
@@ -471,11 +471,13 @@ If you need more details for troubleshooting, increase log verbosity by setting 
 
 ### Symbol Required
 
-Some transaction types require a symbol (ticker):
+Some transaction types require either a ticker symbol or an ISIN:
 
-- `BUY`, `SELL`: Always required.
-- `DIVIDEND`, `TRANSFER_IN`, `TRANSFER_OUT`: Usually required.
+- `BUY`, `SELL`, `DIVIDEND`, `SPLIT`: Always required.
+- `TRANSFER_IN`, `TRANSFER_OUT`, `INTEREST`: Required for asset transactions.
 - `DEPOSIT`, `WITHDRAWAL`, `FEE`, `TAX`, `CREDIT`: Not required.
+
+**Note:** Symbol can also be resolved from ISIN, CUSIP, or company name using an override file. If you provide an ISIN that is mapped to a symbol, both the resolved symbol and the original ISIN will be included in the output CSV.
 
 ## Getting Format Information
 

--- a/docs/limeco-format-user-guide.md
+++ b/docs/limeco-format-user-guide.md
@@ -160,7 +160,7 @@ Recommended mapping:
 2. Current symbol: `META`.
 3. Add symbol override: `FB -> META`.
 
-See [Override Symbols and Resolve Identifiers](user-manual.md#override-symbols-and-resolve-identifiers) for information on how to set up symbol overrides.
+See [Override and Resolve Symbols and ISINs](./user-manual.md#override-and-resolve-symbols-and-isins) for information on how to set up symbol overrides.
 
 ## Format Quirks
 
@@ -192,7 +192,7 @@ Typical interpretation:
 3. Calculated unit price: `25.00 / 100 = 0.25`.
 4. Recommended symbol mapping: `APPLE INC` -> `AAPL`. Without this mapping, dividend symbol will become `APPLE-INC` and a warning will be logged.
 
-See [Override Symbols and Resolve Identifiers](user-manual.md#override-symbols-and-resolve-identifiers) for information on how to set up company name to symbol mappings.
+See [Override and Resolve Symbols and ISINs](./user-manual.md#override-and-resolve-symbols-and-isins) for information on how to set up company name to symbol mappings.
 
 ### Forward and reverse splits are calculated from paired `in` and `out` records<!-- omit from toc -->
 

--- a/docs/technical-information.md
+++ b/docs/technical-information.md
@@ -71,7 +71,7 @@ This document provides technical details about the architecture, design, and imp
   3. Checks the in-memory cache and returns the cached `SymbolResult` on a hit.
   4. Queries providers in registration order, caches the first match, and returns it.
   5. Returns `null` if no provider returns a match.
-- `querySymbolWithFallback()` calls `querySymbol()` and adds a fallback that returns the best available identifier (ISIN -> CUSIP -> sanitized name) when `querySymbol()` returns `null`.
+- `querySymbolWithFallback()` calls `querySymbol()` and adds a fallback that returns the best available identifier (CUSIP -> sanitized name) when `querySymbol()` returns `null`.
 - Exposes registered provider info for diagnostics and logging.
 - Logs successful resolutions at the `INFO` level, cache hits at the `TRACE` level, and unresolvable identifiers at the `WARN` level.
 
@@ -111,6 +111,7 @@ All converters produce CSV with these columns:
 - **date**: Transaction date (ISO format).
 - **instrumentType**: Asset category (see [Instrument Types](#instrument-types) below).
 - **symbol**: Asset symbol/ticker.
+- **isin**: ISIN code (International Securities Identification Number).
 - **quantity**: Number of shares/units.
 - **activityType**: Transaction type (see [Activity Types](#activity-types) below).
 - **unitPrice**: Price per unit.

--- a/docs/technical-information.md
+++ b/docs/technical-information.md
@@ -66,16 +66,16 @@ This document provides technical details about the architecture, design, and imp
 
 - Orchestrates symbol resolution across registered data providers.
 - `querySymbol()` follows these steps:
-  1. Normalizes the query: `symbol`, `ISIN`, and `CUSIP` are trimmed and uppercased; `name` is only trimmed. Fields that become empty after normalization are set to `undefined`. Queries differing only in whitespace or casing are therefore treated as identical.
+  1. Normalizes the query: `symbol`, `ISIN`, and `CUSIP` are trimmed and uppercased; `name` is only trimmed. Fields that become empty after normalization are set to `undefined`. Queries differing only in whitespace (all fields) or casing (all fields, except for `name`) are therefore treated as identical.
   2. Short-circuits when all fields are empty after normalization, returning `null` without querying any provider.
   3. Checks the in-memory cache and returns the cached `SymbolQueryResult` on a hit.
   4. Queries providers in registration order, caches the first match, and returns it.
   5. Returns `null` if no provider returns a match.
-- `querySymbolWithFallback()` calls `querySymbol()` and adds a fallback when no provider has resolved the symbol:
+- `querySymbolWithFallback()` calls `querySymbol()` and adds a fallback when no provider could resolve a symbol or ISIN:
   1. If symbol is present in the query, it returns that symbol (normalized); if ISIN is also present in the query, it also returns that ISIN (normalized).
-  2. If ISIN is present in the query without a symbol, it returns that ISIN (normalized) and the symbol is set to `undefined`.
-  3. If no symbol and ISIN are present in the query, it uses the best available identifier in the priority order: CUSIP (normalized) -> sanitized company name -> `undefined`.
-  4. If all fields are empty in the query, both symbol and ISIN will be set to `undefined`.
+  2. If ISIN is present in the query without a symbol, it returns that ISIN (normalized) and the symbol is set to an empty string.
+  3. If no symbol and ISIN are present in the query, it uses the best available identifier in the priority order: CUSIP (normalized) -> sanitized company name -> empty string.
+  4. If all fields are empty in the query, both symbol and ISIN will be set to an empty string.
 - Exposes registered provider info for diagnostics and logging.
 - Logs successful resolutions at the `INFO` level, cache hits at the `TRACE` level, and unresolvable identifiers at the `WARN` level.
 

--- a/docs/technical-information.md
+++ b/docs/technical-information.md
@@ -66,12 +66,16 @@ This document provides technical details about the architecture, design, and imp
 
 - Orchestrates symbol resolution across registered data providers.
 - `querySymbol()` follows these steps:
-  1. Normalizes the query: `symbol`, `ISIN`, and `CUSIP` are trimmed and uppercased; `name` is only trimmed. Queries differing only in whitespace or casing are therefore treated as identical.
-  2. Short-circuits when all fields are empty after normalization, returning `{ symbol: "", provider: "Fallback" }` without querying any provider.
-  3. Checks the in-memory cache and returns the cached `SymbolResult` on a hit.
+  1. Normalizes the query: `symbol`, `ISIN`, and `CUSIP` are trimmed and uppercased; `name` is only trimmed. Fields that become empty after normalization are set to `undefined`. Queries differing only in whitespace or casing are therefore treated as identical.
+  2. Short-circuits when all fields are empty after normalization, returning `null` without querying any provider.
+  3. Checks the in-memory cache and returns the cached `SymbolQueryResult` on a hit.
   4. Queries providers in registration order, caches the first match, and returns it.
   5. Returns `null` if no provider returns a match.
-- `querySymbolWithFallback()` calls `querySymbol()` and adds a fallback that returns the best available identifier (CUSIP -> sanitized name) when `querySymbol()` returns `null`.
+- `querySymbolWithFallback()` calls `querySymbol()` and adds a fallback when no provider has resolved the symbol:
+  1. If symbol is present in the query, it returns that symbol (normalized); if ISIN is also present in the query, it also returns that ISIN (normalized).
+  2. If ISIN is present in the query without a symbol, it returns that ISIN (normalized) and the symbol is set to `undefined`.
+  3. If no symbol and ISIN are present in the query, it uses the best available identifier in the priority order: CUSIP (normalized) -> sanitized company name -> `undefined`.
+  4. If all fields are empty in the query, both symbol and ISIN will be set to `undefined`.
 - Exposes registered provider info for diagnostics and logging.
 - Logs successful resolutions at the `INFO` level, cache hits at the `TRACE` level, and unresolvable identifiers at the `WARN` level.
 
@@ -97,7 +101,7 @@ The format name is configured through the base class constructor (`super("YourFo
 
 Data providers extend `DataProvider` and implement:
 
-- `query(query)` - Resolves symbol identifiers to a ticker or returns `null`.
+- `query(query)` - Resolves symbol identifiers to a `SymbolResult` (with optional `symbol` and `isin` fields); returns an empty object if cannot resolve.
 - `canHandle(query)` (optional) - Returns `true` if the provider can handle the query, `false` otherwise.
 
 The provider name is configured through the base class constructor (`super("YourProviderName", ...)`) and exposed through `getName()` inherited from `DataProvider`.

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -16,7 +16,7 @@ SPDX-License-Identifier: BSD-3-Clause
     - [Format Auto-detection (default)](#format-auto-detection-default)
     - [Specify the Format Manually](#specify-the-format-manually)
     - [Specify the Default Currency](#specify-the-default-currency)
-    - [Override Symbols and Resolve Identifiers](#override-symbols-and-resolve-identifiers)
+    - [Override and Resolve Symbols and ISINs](#override-and-resolve-symbols-and-isins)
   - [List Supported Formats](#list-supported-formats)
   - [Get Format Information](#get-format-information)
   - [Get Help](#get-help)
@@ -122,7 +122,7 @@ Convert a generic CSV with ISINs, CUSIPs, and company names:
 convert-to-wealthfolio convert examples/sample-generic-isin-cusip-name.csv output.csv
 ```
 
-When both no ticker symbol and no ISIN are present, the converter tries to synthesize a symbol from the following data (in the priority order): CUSIP → sanitized company name → empty symbol. When only ISIN is present, it will be copied to the `isin` column and the `symbol` column will be left empty. To get a proper symbol when it is missing, see [Override Symbols and Resolve Identifiers](#override-symbols-and-resolve-identifiers) section for information on how to resolve identifiers into symbols by using an INI file.
+When both no ticker symbol and no ISIN are present, the converter tries to synthesize a symbol from the following data (in the priority order): CUSIP → sanitized company name → empty symbol. When only ISIN is present, it will be copied to the `isin` column and the `symbol` column will be left empty. To get a proper symbol when it is missing, see [Override and Resolve Symbols and ISINs](#override-and-resolve-symbols-and-isins) section for information on how to resolve identifiers into symbols by using an INI file.
 
 #### Specify the Format Manually
 
@@ -172,13 +172,12 @@ CTW_DEFAULT_CURRENCY=GBP convert-to-wealthfolio convert examples/sample-generic.
 
 **Note:** Some formats may ignore the default currency option and always use their own. Always refer to the documentation of the specific format you're using.
 
-#### Override Symbols and Resolve Identifiers
+#### Override and Resolve Symbols and ISINs
 
-You can override symbols and resolve ISINs, CUSIPs, and company names by passing an INI file to the `--overrides` option:
+You can override symbols and ISINs; resolve symbols from ISINs, CUSIPs, and company names; resolve ISINs from symbols, CUSIPs, and company names. To do this, pass an INI file to the `--overrides` option:
 
 ```bash
 convert-to-wealthfolio convert --overrides <overrides.ini> <input.csv> <output.csv>
-
 ```
 
 E.g., convert a generic CSV file with overrides:
@@ -192,27 +191,54 @@ You will get resolved identifiers, as long as they're present in the override fi
 The overrides file format:
 
 ```ini
-[Symbol]
+# Override ISIN
+[ISIN.ISIN]
+US38259P5089 = US02079K3059
+
+# Map symbol to ISIN
+[ISIN.Symbol]
+AAPL = US0378331005
+
+# Map CUSIP to ISIN
+[ISIN.CUSIP]
+38259P508 = US38259P5089
+
+# Map company name to ISIN
+[ISIN.Name]
+Alphabet Inc. = US02079K3059
+
+# Override symbol
+[Symbol.Symbol]
 FB = META
 
-[ISIN]
-US0378331005 = AAPL
+# Map ISIN to symbol
+[Symbol.ISIN]
+US02079K3059 = GOOGL
 
-[CUSIP]
+# Map CUSIP to symbol
+[Symbol.CUSIP]
 594918104 = MSFT
 
-[Name]
+# Map company name to symbol
+[Symbol.Name]
 Volkswagen AG Preferred = VOW3.DE
 ```
 
+ISIN lookups are performed before symbol lookups, which means that symbol lookups are performed with an already resolved ISIN.
+
 This option is useful for:
 
-- Correcting ticker symbol changes after mergers or rebranding
-- Fixing incorrect identifiers in the source data
-- Standardizing symbol naming across different data sources
-- Mapping ISIN, CUSIP, or company name to a symbol when the original symbol is missing in the source data
+- Correcting ticker symbol and ISIN changes after mergers or rebranding.
+- Fixing incorrect identifiers in the source data.
+- Standardizing symbol naming across different data sources.
+- Mapping ISIN, CUSIP, or company name to a symbol when the original symbol is missing in the source data.
+- Mapping symbol, CUSIP, or company name to an ISIN to complement a symbol.
 
 See [examples/overrides.ini](../examples/overrides.ini) for a template.
+
+**Note**: ISIN, CUSIP, and company name lookups are handled by plugins during conversion. Symbol and ISIN overrides, on the other hand, are done automatically _after_ the conversion. E.g., if you have an ISIN that resolves to a symbol, and that symbol is in the overrides, the override will be applied to the resolved symbol.
+
+**Note**: Symbol resolution results are cached in memory for the duration of the conversion. If the same combination of symbol, ISIN, CUSIP, and company name appears multiple times in the input CSV, the identifier is resolved only once and the result is reused for all matching rows. Cache hits are logged at the `TRACE` level; use `--trace` to see them.
 
 You can also set the path to the overrides file using the `CTW_OVERRIDES` environment variable:
 
@@ -221,10 +247,6 @@ CTW_OVERRIDES="examples/overrides.ini" convert-to-wealthfolio convert examples/s
 ```
 
 **Note:** The CLI option takes precedence over the environment variable if both are set.
-
-**Note**: ISIN, CUSIP, and company name lookups are handled by plugins during conversion. Symbol overrides, on the other hand, are done automatically _after_ the conversion. So if you have an ISIN that resolves to a symbol, and that symbol is in the overrides, the override will be applied to the resolved symbol.
-
-**Note**: Symbol resolution results are cached in memory for the duration of the conversion. If the same combination of symbol, ISIN, CUSIP, and company name appears multiple times in the input CSV, the identifier is resolved only once and the result is reused for all matching rows. Cache hits are logged at the `TRACE` level; use `--trace` to see them.
 
 ### List Supported Formats
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -122,7 +122,7 @@ Convert a generic CSV with ISINs, CUSIPs, and company names:
 convert-to-wealthfolio convert examples/sample-generic-isin-cusip-name.csv output.csv
 ```
 
-You will get ISIN, CUSIP, or sanitized company name as a symbol. See [Override Symbols and Resolve Identifiers](#override-symbols-and-resolve-identifiers) section for information on how to resolve identifiers into symbols by using an INI file.
+When both no ticker symbol and no ISIN are present, the converter tries to synthesize a symbol from the following data (in the priority order): CUSIP → sanitized company name → empty symbol. When only ISIN is present, it will be copied to the `isin` column and the `symbol` column will be left empty. To get a proper symbol when it is missing, see [Override Symbols and Resolve Identifiers](#override-symbols-and-resolve-identifiers) section for information on how to resolve identifiers into symbols by using an INI file.
 
 #### Specify the Format Manually
 

--- a/examples/overrides.ini
+++ b/examples/overrides.ini
@@ -1,45 +1,79 @@
 # Symbol, ISIN, CUSIP, and Company Name Overrides
 #
-# This file allows you to override symbols and map ISIN, CUSIP, and company name
-# identifiers to a symbol. This is useful for:
-# - Correcting ticker symbol changes after mergers or rebranding
-# - Fixing incorrect identifiers in the source data
-# - Standardizing symbol naming across different data sources
+# This file allows you to override ISIN and map symbol, CUSIP and company name
+# to ISIN. It also allows you to override symbols and map ISIN, CUSIP, and
+# company name to a symbol. This is useful for:
+# - Correcting ticker symbol and ISIN changes after mergers or rebranding.
+# - Fixing incorrect identifiers in the source data.
+# - Standardizing symbol naming across different data sources.
 # - Mapping ISIN, CUSIP, and company name to a symbol when the original symbol
-#   is missing in the source data
+#   is missing in the source data.
+# - Mapping symbol, CUSIP, or company name to an ISIN to complement a symbol.
 #
-# Format: Each section is defined by a header in square brackets,
-# followed by key=value pairs where:
-# - key is the original value from the source CSV
-# - value is the replacement that will become a symbol in the output CSV
+# Format: The file is organized into two top-level groups:  [ISIN.*] sections
+# define mappings whose output is an ISIN, and [Symbol.*] sections define
+# mappings whose output is a ticker symbol. Within each group, the sub-section
+# name indicates the type of the key (the lookup identifier):
 #
-# Keys will be compared case-insensitive and trimmed of whitespace. Values will
-# always be converted to uppercase.
+#   [ISIN.ISIN]      override an ISIN with another ISIN
+#   [ISIN.Symbol]    map a symbol to an ISIN
+#   [ISIN.CUSIP]     map a CUSIP to an ISIN
+#   [ISIN.Name]      map a company name to an ISIN
 #
-# Note: Symbol overrides are applied after ISIN, CUSIP, and company name
-# resolution. Which means that if you have an ISIN that resolves to a symbol,
-# and that symbol is in the overrides, the override will be applied to the
-# resolved symbol.
+#   [Symbol.Symbol]  override a symbol with another symbol
+#   [Symbol.ISIN]    map an ISIN to a symbol
+#   [Symbol.CUSIP]   map a CUSIP to a symbol
+#   [Symbol.Name]    map a company name to a symbol
+#
+# Keys are compared case-insensitively and trimmed of whitespace. Values are
+# always converted to uppercase.
+#
+# Note: [ISIN.*] mappings are applied before [Symbol.*] mappings, so if the
+# record's ISIN is overridden or mapped, the resulting ISIN is used for the
+# symbol lookup via [Symbol.ISIN]. [ISIN.ISIN] and [Symbol.Symbol] overrides are
+# always applied after the conversion — this means that overrides will be
+# applied to already mapped identifiers.
 #
 # Lines starting with # or ; are treated as comments and ignored.
 
-[Symbol]
-# Example: Facebook has changed its ticker from FB to META
+# Override ISIN
+[ISIN.ISIN]
+# Google was renamed to Alphabet and its ISIN has changed
+US38259P5089 = US02079K3059
+
+# Map symbol to ISIN
+[ISIN.Symbol]
+AAPL = US0378331005
+
+# Map CUSIP to ISIN
+[ISIN.CUSIP]
+# This will end up as "US02079K3059" due to the ISIN override above. To also get
+# a symbol you either need to have a mapping in [Symbol.CUSIP] with the same
+# CUSIP or in [Symbol.ISIN] with the below ISIN as key.
+38259P508 = US38259P5089
+
+# Map company name to ISIN
+[ISIN.Name]
+Alphabet Inc. = US02079K3059
+
+# Override symbol
+[Symbol.Symbol]
+# Facebook has changed its ticker from FB to META
 FB = META
 
-[ISIN]
-# Example: Override ISIN to use a specific symbol
-US0378331005 = AAPL
-US5949181045 = MSFT
+# Map ISIN to symbol
+[Symbol.ISIN]
 US02079K3059 = GOOGL
 
-[CUSIP]
-# Example: Override CUSIP to use a specific symbol
+# Map CUSIP to symbol
+[Symbol.CUSIP]
 037833100 = AAPL
 594918104 = MSFT
-# This will end up as "META" because of the symbol override above
+# This will end up as "META" due to the symbol override above
 30303M102 = FB
+# Needed for example in [ISIN.CUSIP] to also get a symbol
+38259P508 = GOOGL
 
-[Name]
-# Example: Override company name to use a specific symbol
+# Map company name to symbol
+[Symbol.Name]
 Volkswagen AG Preferred = VOW3.DE

--- a/examples/sample-generic-isin-cusip-name.csv
+++ b/examples/sample-generic-isin-cusip-name.csv
@@ -1,6 +1,10 @@
 Date,TransactionType,Symbol,ISIN,CUSIP,CompanyName,Quantity,UnitPrice,Fee,Total,Currency,Comment
-2024-02-20,SELL,FB,,,,50,380.50,9.99,19015.01,USD,Resolved via Symbol (META)
-2024-01-15,BUY,,US0378331005,,,100,150.25,9.99,15034.99,USD,Resolved via ISIN (AAPL)
-2024-02-20,SELL,,,594918104,,50,380.50,9.99,19015.01,USD,Resolved via CUSIP (MSFT)
-2024-03-10,DIVIDEND,,US02079K3059,02079K305,Alphabet. Inc.,100,2.50,0,250.00,USD,Resolved via ISIN (GOOGL)
-2024-04-05,BUY,,,,Volkswagen AG Preferred,200,75.00,9.99,15009.99,USD,Resolved via company name (VOW3.DE)
+2024-01-05,BUY,,,30303M102,,50,380.50,9.99,19034.99,USD,Symbol overriden (META)
+2024-02-10,BUY,,US38259P5089,,,100,250.00,0,25000.00,USD,ISIN overriden (US02079K3059)
+2024-03-15,DIVIDEND,,US02079K3059,02079K305,Alphabet. Inc.,100,2.50,0,250.00,USD,Symbol resolved via ISIN (GOOGL)
+2024-04-20,SELL,,,594918104,,50,380.50,9.99,19015.01,USD,Symbol resolved via CUSIP (MSFT)
+2024-05-25,BUY,,,38259P508,,150,700.00,9.99,104990.01,USD,ISIN resolved via CUSIP (US02079K3059)
+2023-06-30,SELL,FB,,,,50,399.99,9.99,19989.51,USD,Symbol resolved via CUSIP (FB) and overriden after that (META)
+2024-07-05,BUY,,,037833100,,100,150.25,9.99,15034.99,USD,"Symbol resolved via CUSIP (AAPL), ISIN resolved via symbol after that (US0378331005)"
+2024-08-10,BUY,,,,Volkswagen AG Preferred,200,75.00,9.99,15009.99,USD,Symbol resolved via company name (VOW3.DE)
+2024-09-15,SELL,,,,Alphabet Inc.,150,700.00,9.99,104990.01,USD,ISIN resolved via company name (US02079K3059)

--- a/src/core/BaseFormat.ts
+++ b/src/core/BaseFormat.ts
@@ -87,6 +87,7 @@ export interface WealthfolioRecord {
   date: Date;
   instrumentType: InstrumentType;
   symbol: string;
+  isin: string;
   quantity: number;
   activityType: ActivityType;
   unitPrice: number;

--- a/src/core/Converter.ts
+++ b/src/core/Converter.ts
@@ -16,7 +16,7 @@ import { Logger } from "./Logger";
 import { SymbolDataService } from "./SymbolDataService";
 import { parseNumber, roundToPrecision } from "./Utils";
 
-import { Overrides, OverridesDataProvider, parseOverridesFile } from "../data-providers";
+import { OverridesByType, OverridesDataProvider, parseOverridesFile } from "../data-providers";
 
 // https://wealthfolio.app/docs/concepts/activity-types/ states that
 // "eight-decimal precision is accepted"
@@ -139,7 +139,7 @@ export class Converter {
     }
 
     const symbolDataService = new SymbolDataService();
-    let overrides: Overrides | undefined;
+    let overrides: OverridesByType | undefined;
     // Load overrides if provided and register as a data provider
     if (overridesPath) {
       overrides = parseOverridesFile(overridesPath);
@@ -147,7 +147,7 @@ export class Converter {
     }
 
     // Convert records
-    const convertedRecords = format
+    let convertedRecords = format
       .convert(records, defaultCurrency, symbolDataService)
       // Filter all records that don't meet field requirements
       .filter((record, index) => {
@@ -162,35 +162,31 @@ export class Converter {
           }
         }
         return result.valid;
-      })
-      .map((record, index) => {
-        // If overrides file was provided, apply symbol overrides.
-        if (overrides?.symbols && overrides.symbols.size > 0) {
-          const newRecord = { ...record };
-          const key = newRecord.symbol.trim().toUpperCase();
-          if (!key) {
-            // Ignore empty symbols (usually cash transactions)
-            logger.trace(
-              `Skipping symbol override for record ${bold(index + 1)}: ${bold("empty")} symbol`,
-            );
-            return newRecord;
-          }
-          const mappedSymbol = overrides.symbols.get(key);
-          if (mappedSymbol) {
-            logger.debug(
-              `Overriding symbol for record ${bold(index + 1)}: ${bold(newRecord.symbol)} -> ${bold(mappedSymbol)}`,
-            );
-            newRecord.symbol = mappedSymbol;
-          } else if (newRecord.symbol !== key) {
-            logger.info(
-              `Normalizing symbol for record ${bold(index + 1)}: ${bold(newRecord.symbol)} -> ${bold(key)}`,
-            );
-            newRecord.symbol = key; // Ensure symbol is normalized, even if no override
-          }
-          return newRecord;
-        }
-        return record;
       });
+
+    const symbolOverrides = overrides?.symbol;
+    const isinOverrides = overrides?.isin;
+    if (
+      (symbolOverrides && symbolOverrides.symbols.size > 0) ||
+      (isinOverrides && isinOverrides.isins.size > 0)
+    ) {
+      // If overrides file was provided, apply symbol and ISIN overrides.
+      convertedRecords = convertedRecords.map((record, index) => {
+        const newRecord = { ...record };
+        if (symbolOverrides) {
+          newRecord.symbol = this.getOverrideFor(
+            newRecord.symbol,
+            symbolOverrides.symbols,
+            index,
+            "symbol",
+          );
+        }
+        if (isinOverrides) {
+          newRecord.isin = this.getOverrideFor(newRecord.isin, isinOverrides.isins, index, "ISIN");
+        }
+        return newRecord;
+      });
+    }
 
     // Write output CSV
     await this.writeCSV(outputPath, convertedRecords);
@@ -289,5 +285,45 @@ export class Converter {
    */
   getRegisteredFormats(): string[] {
     return this.formatPlugins.map((p) => p.getName());
+  }
+
+  /**
+   * Get override value for a given key from the overrides map
+   *
+   * @param key - Original value to check for override
+   * @param overridesMap - Map of overrides to check against
+   * @param recordIndex - Index of the record being processed (for logging)
+   * @param fieldName - Name of the field being overridden (for logging)
+   * @returns Overridden value if found, otherwise the original key (possibly normalized)
+   */
+  private getOverrideFor(
+    key: string,
+    overridesMap: Map<string, string>,
+    recordIndex: number,
+    fieldName: string,
+  ): string {
+    const logger = Logger.getInstance();
+
+    const normalizedKey = key.trim().toUpperCase();
+    if (!normalizedKey) {
+      logger.trace(
+        `Skipping ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold("empty")} value`,
+      );
+      return "";
+    }
+
+    const mappedValue = overridesMap.get(normalizedKey);
+    if (mappedValue) {
+      logger.debug(
+        `Overriding ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold(key)} -> ${bold(mappedValue)}`,
+      );
+      return mappedValue;
+    } else if (key !== normalizedKey) {
+      logger.info(
+        `Normalizing ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold(key)} -> ${bold(normalizedKey)}`,
+      );
+      return normalizedKey; // Normalize even if no override
+    }
+    return normalizedKey; // No change
   }
 }

--- a/src/core/DataProvider.ts
+++ b/src/core/DataProvider.ts
@@ -13,9 +13,11 @@ export interface DataProviderInfo {
 
 /**
  * Query parameters for symbol lookup
+ *
+ * At least one of `symbol`, `isin`, `cusip`, or `name` should be provided for a valid query.
  */
 export interface SymbolQuery {
-  /** Symbol/ticker name (e.g., AAPL, or can be the key for lookup) */
+  /** Symbol / ticker name */
   symbol?: string;
   /** ISIN code */
   isin?: string;
@@ -23,6 +25,18 @@ export interface SymbolQuery {
   cusip?: string;
   /** Company/asset name */
   name?: string;
+}
+
+/**
+ * Result of a symbol query
+ *
+ * At least one of `symbol` or `isin` will be present if the query was successfully resolved.
+ */
+export interface SymbolResult {
+  /** Resolved symbol / ticker name */
+  symbol?: string;
+  /** Resolved ISIN code */
+  isin?: string;
 }
 
 /**
@@ -56,9 +70,9 @@ export abstract class DataProvider {
    * Query for a symbol and related identifiers
    *
    * @param query - Symbol query parameters
-   * @returns Resolved symbol string or `null` if not found
+   * @returns Resolved symbol result or empty object if cannot resolve
    */
-  abstract query(query: SymbolQuery): string | null;
+  abstract query(query: SymbolQuery): SymbolResult;
 
   /**
    * Optional: Check if this provider can handle the query

--- a/src/core/FieldRequirements.ts
+++ b/src/core/FieldRequirements.ts
@@ -144,6 +144,56 @@ function clearField(record: WealthfolioRecord, field: keyof WealthfolioRecord): 
 }
 
 /**
+ * Helper function for fields that are required when ISIN is not set
+ *
+ * Returns `FieldRequirement.Required` if ISIN is not set, otherwise returns `FieldRequirement.Optional`.
+ *
+ * @param record - The Wealthfolio record to check
+ * @returns Field requirement based on the presence of ISIN
+ */
+function requiredWhenNoIsinElseOptional(record: WealthfolioRecord): FieldRequirement {
+  return record.isin ? FieldRequirement.Optional : FieldRequirement.Required;
+}
+
+/**
+ * Helper function for fields that are required when symbol is not set
+ *
+ * Returns `FieldRequirement.Required` if symbol is not set, otherwise returns `FieldRequirement.Optional`.
+ *
+ * @param record - The Wealthfolio record to check
+ * @returns Field requirement based on the presence of symbol
+ */
+function requiredWhenNoSymbolElseOptional(record: WealthfolioRecord): FieldRequirement {
+  return record.symbol ? FieldRequirement.Optional : FieldRequirement.Required;
+}
+
+/**
+ * Helper function for fields that are required for asset transactions
+ *
+ * Returns `FieldRequirement.Required` when transaction is for an asset (symbol or ISIN is set),
+ * otherwise returns `FieldRequirement.Ignored`.
+ *
+ * @param record - The Wealthfolio record to check
+ * @returns Field requirement based on the presence of symbol or ISIN
+ */
+function requiredWhenAssetTransactionElseIgnored(record: WealthfolioRecord): FieldRequirement {
+  return !!record.symbol || !!record.isin ? FieldRequirement.Required : FieldRequirement.Ignored;
+}
+
+/**
+ * Helper function for fields that are optional for asset transactions
+ *
+ * Returns `FieldRequirement.Optional` when transaction is for an asset (symbol or ISIN is set),
+ * otherwise returns `FieldRequirement.Ignored`.
+ *
+ * @param record - The Wealthfolio record to check
+ * @returns Field requirement based on the presence of symbol or ISIN
+ */
+function optionalWhenAssetTransactionElseIgnored(record: WealthfolioRecord): FieldRequirement {
+  return !!record.symbol || !!record.isin ? FieldRequirement.Optional : FieldRequirement.Ignored;
+}
+
+/**
  * Field requirement levels in a Wealthfolio record
  */
 enum FieldRequirement {
@@ -188,7 +238,8 @@ const RECORD_FIELD_REQUIREMENTS: {
   [ActivityType.Buy]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Optional,
-    symbol: FieldRequirement.Required,
+    symbol: requiredWhenNoIsinElseOptional,
+    isin: requiredWhenNoSymbolElseOptional,
     quantity: FieldRequirement.Required,
     unitPrice: FieldRequirement.Required,
     amount: FieldRequirement.Optional,
@@ -196,7 +247,8 @@ const RECORD_FIELD_REQUIREMENTS: {
   [ActivityType.Sell]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Optional,
-    symbol: FieldRequirement.Required,
+    symbol: requiredWhenNoIsinElseOptional,
+    isin: requiredWhenNoSymbolElseOptional,
     quantity: FieldRequirement.Required,
     unitPrice: FieldRequirement.Required,
     amount: FieldRequirement.Optional,
@@ -204,7 +256,8 @@ const RECORD_FIELD_REQUIREMENTS: {
   [ActivityType.Dividend]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Optional,
-    symbol: FieldRequirement.Required,
+    symbol: requiredWhenNoIsinElseOptional,
+    isin: requiredWhenNoSymbolElseOptional,
     quantity: FieldRequirement.Optional,
     unitPrice: (record) =>
       // DRIP and dividend in kind subtypes require unit price for cost basis calculation
@@ -222,13 +275,13 @@ const RECORD_FIELD_REQUIREMENTS: {
   },
   [ActivityType.Interest]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: (record) =>
-      record.symbol ? FieldRequirement.Optional : FieldRequirement.Ignored,
+    instrumentType: optionalWhenAssetTransactionElseIgnored,
     symbol: FieldRequirement.Optional,
+    isin: FieldRequirement.Optional,
     quantity: FieldRequirement.Ignored,
     unitPrice: (record) =>
-      // Staking reward subtype requires unit price (fair market value at time of reward) for cost
-      // basis calculation
+      // Staking reward subtype requires unit price (fair market value at the time of reward) for
+      // cost basis calculation
       record.subtype === ActivitySubtype.StakingReward
         ? FieldRequirement.Required
         : FieldRequirement.Ignored,
@@ -239,6 +292,7 @@ const RECORD_FIELD_REQUIREMENTS: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Ignored,
     symbol: FieldRequirement.Ignored,
+    isin: FieldRequirement.Ignored,
     quantity: FieldRequirement.Ignored,
     unitPrice: FieldRequirement.Ignored,
     amount: FieldRequirement.Required,
@@ -247,32 +301,36 @@ const RECORD_FIELD_REQUIREMENTS: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Ignored,
     symbol: FieldRequirement.Ignored,
+    isin: FieldRequirement.Ignored,
     quantity: FieldRequirement.Ignored,
     unitPrice: FieldRequirement.Ignored,
     amount: FieldRequirement.Required,
   },
   [ActivityType.TransferIn]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: (record) =>
-      record.symbol ? FieldRequirement.Optional : FieldRequirement.Ignored,
+    instrumentType: optionalWhenAssetTransactionElseIgnored,
     symbol: FieldRequirement.Optional,
-    quantity: (record) => (record.symbol ? FieldRequirement.Required : FieldRequirement.Ignored),
-    unitPrice: (record) => (record.symbol ? FieldRequirement.Required : FieldRequirement.Ignored),
-    amount: (record) => (record.symbol ? FieldRequirement.Ignored : FieldRequirement.Required),
+    isin: FieldRequirement.Optional,
+    quantity: requiredWhenAssetTransactionElseIgnored,
+    unitPrice: requiredWhenAssetTransactionElseIgnored,
+    amount: (record) =>
+      record.symbol || record.isin ? FieldRequirement.Ignored : FieldRequirement.Required,
   },
   [ActivityType.TransferOut]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: (record) =>
-      record.symbol ? FieldRequirement.Optional : FieldRequirement.Ignored,
+    instrumentType: optionalWhenAssetTransactionElseIgnored,
     symbol: FieldRequirement.Optional,
-    quantity: (record) => (record.symbol ? FieldRequirement.Required : FieldRequirement.Ignored),
-    unitPrice: (record) => (record.symbol ? FieldRequirement.Required : FieldRequirement.Ignored),
-    amount: (record) => (record.symbol ? FieldRequirement.Ignored : FieldRequirement.Required),
+    isin: FieldRequirement.Optional,
+    quantity: requiredWhenAssetTransactionElseIgnored,
+    unitPrice: requiredWhenAssetTransactionElseIgnored,
+    amount: (record) =>
+      record.symbol || record.isin ? FieldRequirement.Ignored : FieldRequirement.Required,
   },
   [ActivityType.Fee]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Ignored,
     symbol: FieldRequirement.Ignored,
+    isin: FieldRequirement.Ignored,
     quantity: FieldRequirement.Ignored,
     unitPrice: FieldRequirement.Ignored,
     // Amount or fee - we'll use the amount
@@ -284,6 +342,7 @@ const RECORD_FIELD_REQUIREMENTS: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Ignored,
     symbol: FieldRequirement.Ignored,
+    isin: FieldRequirement.Ignored,
     quantity: FieldRequirement.Ignored,
     unitPrice: FieldRequirement.Ignored,
     amount: FieldRequirement.Required,
@@ -292,7 +351,8 @@ const RECORD_FIELD_REQUIREMENTS: {
   [ActivityType.Split]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Optional,
-    symbol: FieldRequirement.Required,
+    symbol: requiredWhenNoIsinElseOptional,
+    isin: requiredWhenNoSymbolElseOptional,
     quantity: FieldRequirement.Ignored,
     unitPrice: FieldRequirement.Ignored,
     currency: FieldRequirement.Ignored,
@@ -303,6 +363,7 @@ const RECORD_FIELD_REQUIREMENTS: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: FieldRequirement.Ignored,
     symbol: FieldRequirement.Ignored,
+    isin: FieldRequirement.Ignored,
     quantity: FieldRequirement.Ignored,
     unitPrice: FieldRequirement.Ignored,
     amount: FieldRequirement.Required,
@@ -311,9 +372,9 @@ const RECORD_FIELD_REQUIREMENTS: {
   // Documentation just states that field requirement "Varies by use case"
   [ActivityType.Adjustment]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: (record) =>
-      record.symbol ? FieldRequirement.Optional : FieldRequirement.Ignored,
+    instrumentType: optionalWhenAssetTransactionElseIgnored,
     symbol: FieldRequirement.Optional,
+    isin: FieldRequirement.Optional,
     quantity: FieldRequirement.Optional,
     unitPrice: FieldRequirement.Optional,
     currency: FieldRequirement.Optional,
@@ -324,9 +385,9 @@ const RECORD_FIELD_REQUIREMENTS: {
   // flagged for review". Either ignore the whole activity or simply pass all fields through?
   [ActivityType.Unknown]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: (record) =>
-      record.symbol ? FieldRequirement.Optional : FieldRequirement.Ignored,
+    instrumentType: optionalWhenAssetTransactionElseIgnored,
     symbol: FieldRequirement.Optional,
+    isin: FieldRequirement.Optional,
     quantity: FieldRequirement.Optional,
     unitPrice: FieldRequirement.Optional,
     currency: FieldRequirement.Optional,

--- a/src/core/SymbolDataService.ts
+++ b/src/core/SymbolDataService.ts
@@ -5,21 +5,20 @@
 
 import { bold } from "colorette";
 
-import { DataProvider, DataProviderInfo, SymbolQuery } from "./DataProvider";
+import { DataProvider, DataProviderInfo, SymbolQuery, SymbolResult } from "./DataProvider";
 import { Logger } from "./Logger";
-import { formatLoggedValue, sanitizeName } from "./Utils";
-
-// TODO: Should we use "UNKNOWN" or something similar here instead of an empty string?
-const UNKNOWN_SYMBOL = "";
+import { formatLoggedValue, formatPair, sanitizeName } from "./Utils";
 
 const FALLBACK_PROVIDER_NAME = "Fallback";
 
 /**
  * Result from a symbol query
  */
-export interface SymbolResult {
+export interface SymbolQueryResult {
   /** Resolved symbol */
-  symbol: string;
+  symbol?: string;
+  /** Resolved ISIN */
+  isin?: string;
   /** Which provider this result came from */
   provider: string;
 }
@@ -29,7 +28,7 @@ export interface SymbolResult {
  */
 export class SymbolDataService {
   private providers: DataProvider[] = [];
-  private resolutionCache: Record<string, SymbolResult> = {};
+  private resolutionCache: Record<string, SymbolQueryResult> = {};
 
   /**
    * Register a data provider
@@ -57,9 +56,8 @@ export class SymbolDataService {
    * only trimmed. Therefore, queries that differ only in whitespace or casing are treated as
    * identical.
    *
-   * **Note:** If all query fields end up missing or empty after normalization, providers are not
-   * queried and a result with an empty symbol is returned immediately, as there is no meaningful
-   * way to resolve an empty query.
+   * **Note:** If all query fields end up missing after normalization, providers are not queried and
+   * `null` is returned immediately, as there is no meaningful way to resolve an empty query.
    *
    * **Note:** If a cache hit contains result from the fallback provider, it will be treated as no
    * result from providers and `null` will be returned immediately. This is because fallback result
@@ -69,7 +67,7 @@ export class SymbolDataService {
    * @param query - Symbol query parameters
    * @returns Symbol result from the first provider that has data, or `null` if no provider could resolve the symbol
    */
-  querySymbol(query: SymbolQuery): SymbolResult | null {
+  querySymbol(query: SymbolQuery): SymbolQueryResult | null {
     const logger = Logger.getInstance();
 
     const normalizedQuery = this.normalizeQuery(query);
@@ -80,12 +78,9 @@ export class SymbolDataService {
       !normalizedQuery.name
     ) {
       logger.warn(
-        `Received a query with ${bold("all fields missing or empty")} -> returning ${bold("empty")} symbol`,
+        `Received a query with ${bold("all fields missing or empty")} -> returning ${bold("null")}`,
       );
-      return {
-        symbol: UNKNOWN_SYMBOL,
-        provider: FALLBACK_PROVIDER_NAME,
-      };
+      return null;
     }
 
     const formattedQuery = this.formatQueryForLogging(query);
@@ -96,12 +91,9 @@ export class SymbolDataService {
         // query last time it was attempted, so we can skip querying providers again
         return null;
       } else {
-        if (cachedResult.symbol !== query.symbol) {
-          // Log only if the resulting symbol is different from the original query symbol
-          logger.trace(
-            `Using cached result for ${formattedQuery} -> ${bold(cachedResult.symbol)} (provider: ${bold(cachedResult.provider)})`,
-          );
-        }
+        logger.trace(
+          `Using cached result for ${formattedQuery} -> ${formatPair([cachedResult.symbol, cachedResult.isin], ["Symbol ", "ISIN "])} (provider: ${bold(cachedResult.provider)})`,
+        );
 
         return cachedResult;
       }
@@ -109,22 +101,16 @@ export class SymbolDataService {
 
     // Try each provider in registration order
     for (const provider of this.providers) {
-      if (!provider.canHandle(normalizedQuery)) {
+      const result = this.queryProvider(provider, normalizedQuery);
+      if (!result) {
         continue;
       }
 
-      const symbol = provider.query(normalizedQuery);
-      if (symbol) {
-        const result = {
-          symbol,
-          provider: provider.getName(),
-        };
-        logger.info(
-          `Resolved ${formattedQuery} -> ${bold(result.symbol)} (provider: ${bold(result.provider)})`,
-        );
+      logger.info(
+        `Resolved ${formattedQuery} -> ${formatPair([result.symbol, result.isin], ["Symbol ", "ISIN "])} (provider: ${bold(result.provider)})`,
+      );
 
-        return this.addToCache(normalizedQuery, result);
-      }
+      return this.addToCache(normalizedQuery, result);
     }
 
     // No provider found a result
@@ -137,7 +123,7 @@ export class SymbolDataService {
    * @param query - Symbol query parameters
    * @returns Symbol result with fallback to original values, never null
    */
-  querySymbolWithFallback(query: SymbolQuery): SymbolResult {
+  querySymbolWithFallback(query: SymbolQuery): SymbolQueryResult {
     const result = this.querySymbol(query);
     if (result) {
       return result;
@@ -152,29 +138,32 @@ export class SymbolDataService {
       // `querySymbol()` will return `null` for fallback cache entries, so we need to re-check the
       // cache for a fallback result.
       logger.trace(
-        `Using cached result for ${formattedQuery} -> ${bold(cachedResult.symbol)} (provider: ${bold(cachedResult.provider)})`,
+        `Using cached result for ${formattedQuery} -> ${formatPair([cachedResult.symbol, cachedResult.isin], ["Symbol ", "ISIN "])} (provider: ${bold(cachedResult.provider)})`,
       );
       return cachedResult;
     }
 
     // Fallback: return the symbol based on the original query values in the priority order: symbol,
-    // CUSIP, sanitized name
+    // unknown symbol when ISIN is present, CUSIP, sanitized name
     const symbol =
       normalizedQuery.symbol ||
-      // If ISIN is known, don't fallback to CUSIP or name, as ISIN should be included in the
-      // dedicated column of the output in this case
+      // If ISIN is known, don't fallback to CUSIP or name, as ISIN will be returned in the result
+      // and should be included in the dedicated column of the output CSV
       (normalizedQuery.isin
-        ? UNKNOWN_SYMBOL
-        : normalizedQuery.cusip || sanitizeName(normalizedQuery.name, UNKNOWN_SYMBOL));
+        ? undefined
+        : normalizedQuery.cusip || sanitizeName(normalizedQuery.name));
 
     // When query has a symbol and resolution doesn't return a result, this only means that there is
     // no override for that symbol. So we only log when there is no symbol in the query.
     if (!normalizedQuery.symbol) {
-      logger.warn(`Couldn't resolve ${formattedQuery} -> falling back to ${bold(symbol)}`);
+      logger.warn(
+        `Couldn't resolve ${formattedQuery} -> falling back to ${formatPair([symbol, normalizedQuery.isin], ["symbol ", "ISIN "])}`,
+      );
     }
 
     return this.addToCache(normalizedQuery, {
       symbol,
+      isin: normalizedQuery.isin,
       provider: FALLBACK_PROVIDER_NAME,
     });
   }
@@ -210,6 +199,45 @@ export class SymbolDataService {
   }
 
   /**
+   * Query the data provider with additional guard against provider returning query values
+   *
+   * @param provider - Data provider to query
+   * @param normalizedQuery - Symbol query parameters
+   * @returns Resolved symbol result if provider returns a result, `null` otherwise
+   */
+  private queryProvider(
+    provider: DataProvider,
+    normalizedQuery: SymbolQuery,
+  ): SymbolQueryResult | null {
+    if (!provider.canHandle(normalizedQuery)) {
+      return null;
+    }
+
+    let { symbol, isin } = this.normalizeProviderResult(provider.query(normalizedQuery));
+
+    // In addition to empty values, guard against providers returning symbol and ISIN that are
+    // identical to the query (i.e. when they simply copy the query values)
+    if (!symbol || symbol === normalizedQuery.symbol) {
+      symbol = undefined;
+    }
+    if (!isin || isin === normalizedQuery.isin) {
+      isin = undefined;
+    }
+
+    if (!symbol && !isin) {
+      return null;
+    }
+
+    // Normalize the result from the provider as well in case the provider returns values with extra
+    // whitespace or inconsistent casing
+    return {
+      symbol,
+      isin,
+      provider: provider.getName(),
+    };
+  }
+
+  /**
    * Format a symbol query for logging
    *
    * The resulting string includes only non-empty fields with appropriate labels and formatting.
@@ -224,16 +252,34 @@ export class SymbolDataService {
   /**
    * Normalize a symbol query by trimming whitespace and uppercasing identifiers
    *
-   * `symbol`, `isin`, and `cusip` are trimmed and uppercased; `name` is only trimmed. This ensures
-   * that queries that differ only in whitespace or casing are treated as identical for caching and
-   * provider querying purposes.
+   * `symbol`, `isin`, and `cusip` are trimmed and uppercased; `name` is only trimmed. Empty values
+   * are converted to `undefined`. This ensures that queries that differ only in whitespace or
+   * casing are treated as identical for caching and provider querying purposes.
+   *
+   * @param query - Symbol query to normalize
+   * @returns Normalized symbol query
    */
   private normalizeQuery(query: SymbolQuery): SymbolQuery {
     return {
-      symbol: query.symbol?.trim().toUpperCase(),
-      isin: query.isin?.trim().toUpperCase(),
-      cusip: query.cusip?.trim().toUpperCase(),
-      name: query.name?.trim(),
+      symbol: query.symbol?.trim().toUpperCase() || undefined,
+      isin: query.isin?.trim().toUpperCase() || undefined,
+      cusip: query.cusip?.trim().toUpperCase() || undefined,
+      name: query.name?.trim() || undefined,
+    };
+  }
+
+  /**
+   * Normalize a symbol query result by trimming whitespace and uppercasing the symbol and ISIN
+   *
+   * All fields are trimmed and uppercased. Empty values are converted to `undefined`.
+   *
+   * @param result - Symbol query result to normalize
+   * @returns Normalized symbol query result
+   */
+  private normalizeProviderResult(result: SymbolResult): SymbolResult {
+    return {
+      symbol: result.symbol?.trim().toUpperCase() || undefined,
+      isin: result.isin?.trim().toUpperCase() || undefined,
     };
   }
 
@@ -247,7 +293,7 @@ export class SymbolDataService {
    * @param result - Symbol result to cache
    * @returns `query` that was passed as an argument (for method chaining)
    */
-  private addToCache(query: SymbolQuery, result: SymbolResult): SymbolResult {
+  private addToCache(query: SymbolQuery, result: SymbolQueryResult): SymbolQueryResult {
     const cacheKey = JSON.stringify(query);
     // Store a copy to prevent external mutations from affecting the cache
     this.resolutionCache[cacheKey] = { ...result };
@@ -263,7 +309,7 @@ export class SymbolDataService {
    * @param query - Symbol query, preferably normalized
    * @returns Cached symbol result if found, or `undefined` if not in cache
    */
-  private getFromCache(query: SymbolQuery): SymbolResult | undefined {
+  private getFromCache(query: SymbolQuery): SymbolQueryResult | undefined {
     const cacheKey = JSON.stringify(query);
     const result = this.resolutionCache[cacheKey];
     // Return a copy to prevent external mutations from affecting the cache

--- a/src/core/SymbolDataService.ts
+++ b/src/core/SymbolDataService.ts
@@ -118,33 +118,60 @@ export class SymbolDataService {
   }
 
   /**
-   * Query with fallback - returns a result with fallback to original query values
+   * Returns a result with fallback to the original query values
+   *
+   * `symbol` and `isin` will never be `undefined` in the returned result — if they are missing from
+   * the provider result, they will be replaced with the original query values or empty strings.
+   *
+   * This simplifies the logic for format plugins that want to use symbol resolution as returned
+   * values can be used directly without additional checks and fallbacks.
    *
    * @param query - Symbol query parameters
-   * @returns Symbol result with fallback to original values, never null
+   * @returns Symbol result with fallback to the original query values or empty strings
    */
-  querySymbolWithFallback(query: SymbolQuery): SymbolQueryResult {
+  querySymbolWithFallback(query: SymbolQuery): Required<SymbolQueryResult> {
+    const logger = Logger.getInstance();
+    const normalizedQuery = this.normalizeQuery(query);
+    if (
+      !normalizedQuery.symbol &&
+      !normalizedQuery.isin &&
+      !normalizedQuery.cusip &&
+      !normalizedQuery.name
+    ) {
+      logger.warn(
+        `Received a query with ${bold("all fields missing or empty")} -> returning ${bold("empty")} result`,
+      );
+
+      return {
+        symbol: "",
+        isin: "",
+        provider: FALLBACK_PROVIDER_NAME,
+      };
+    }
+
+    const fallbackSymbol = normalizedQuery.symbol || "";
+    const fallbackISIN = normalizedQuery.isin || "";
+
     const result = this.querySymbol(query);
     if (result) {
+      return this.withFallbackValues(result, fallbackSymbol, fallbackISIN);
+    }
+
+    const formattedQuery = this.formatQueryForLogging(query);
+
+    // `querySymbol()` will return `null` for fallback cache entries, so we need to re-check the
+    // cache for a fallback result.
+    const cachedResult = this.getFromCache(normalizedQuery);
+    if (cachedResult) {
+      const result = this.withFallbackValues(cachedResult, fallbackSymbol, fallbackISIN);
+      logger.trace(
+        `Using cached result for ${formattedQuery} -> ${formatPair([result.symbol, result.isin], ["Symbol ", "ISIN "])} (provider: ${bold(result.provider)})`,
+      );
       return result;
     }
 
-    const logger = Logger.getInstance();
-    const normalizedQuery = this.normalizeQuery(query);
-    const formattedQuery = this.formatQueryForLogging(query);
-
-    const cachedResult = this.getFromCache(normalizedQuery);
-    if (cachedResult) {
-      // `querySymbol()` will return `null` for fallback cache entries, so we need to re-check the
-      // cache for a fallback result.
-      logger.trace(
-        `Using cached result for ${formattedQuery} -> ${formatPair([cachedResult.symbol, cachedResult.isin], ["Symbol ", "ISIN "])} (provider: ${bold(cachedResult.provider)})`,
-      );
-      return cachedResult;
-    }
-
-    // Fallback: return the symbol based on the original query values in the priority order: symbol,
-    // unknown symbol when ISIN is present, CUSIP, sanitized name
+    // For fallback, synthesize a symbol based on the original query values in the priority order:
+    // symbol, empty symbol when ISIN is present, CUSIP, sanitized name
     const symbol =
       normalizedQuery.symbol ||
       // If ISIN is known, don't fallback to CUSIP or name, as ISIN will be returned in the result
@@ -153,19 +180,25 @@ export class SymbolDataService {
         ? undefined
         : normalizedQuery.cusip || sanitizeName(normalizedQuery.name));
 
+    const fallbackResult = this.withFallbackValues(
+      this.addToCache(normalizedQuery, {
+        symbol,
+        isin: normalizedQuery.isin,
+        provider: FALLBACK_PROVIDER_NAME,
+      }),
+      fallbackSymbol,
+      fallbackISIN,
+    );
+
     // When query has a symbol and resolution doesn't return a result, this only means that there is
     // no override for that symbol. So we only log when there is no symbol in the query.
     if (!normalizedQuery.symbol) {
       logger.warn(
-        `Couldn't resolve ${formattedQuery} -> falling back to ${formatPair([symbol, normalizedQuery.isin], ["symbol ", "ISIN "])}`,
+        `Couldn't resolve ${formattedQuery} -> falling back to ${formatPair([fallbackResult.symbol, fallbackResult.isin], ["symbol ", "ISIN "])}`,
       );
     }
 
-    return this.addToCache(normalizedQuery, {
-      symbol,
-      isin: normalizedQuery.isin,
-      provider: FALLBACK_PROVIDER_NAME,
-    });
+    return fallbackResult;
   }
 
   /**
@@ -338,5 +371,25 @@ export class SymbolDataService {
         delete this.resolutionCache[key];
       }
     }
+  }
+
+  /**
+   * Combine a symbol query result with fallback values for missing fields
+   *
+   * @param result - Symbol query result to combine with fallback values
+   * @param symbol - Fallback symbol to use if `result.symbol` is missing
+   * @param isin - Fallback ISIN to use if `result.isin` is missing
+   * @returns A new symbol query result with fallback values for missing fields, guaranteed to have `symbol` and `isin`
+   */
+  private withFallbackValues(
+    result: SymbolQueryResult,
+    symbol: string,
+    isin: string,
+  ): Required<SymbolQueryResult> {
+    return {
+      symbol: result.symbol || symbol,
+      isin: result.isin || isin,
+      provider: result.provider,
+    };
   }
 }

--- a/src/core/SymbolDataService.ts
+++ b/src/core/SymbolDataService.ts
@@ -158,12 +158,14 @@ export class SymbolDataService {
     }
 
     // Fallback: return the symbol based on the original query values in the priority order: symbol,
-    // ISIN, CUSIP, sanitized name
+    // CUSIP, sanitized name
     const symbol =
       normalizedQuery.symbol ||
-      normalizedQuery.isin ||
-      normalizedQuery.cusip ||
-      sanitizeName(normalizedQuery.name, UNKNOWN_SYMBOL);
+      // If ISIN is known, don't fallback to CUSIP or name, as ISIN should be included in the
+      // dedicated column of the output in this case
+      (normalizedQuery.isin
+        ? UNKNOWN_SYMBOL
+        : normalizedQuery.cusip || sanitizeName(normalizedQuery.name, UNKNOWN_SYMBOL));
 
     // When query has a symbol and resolution doesn't return a result, this only means that there is
     // no override for that symbol. So we only log when there is no symbol in the query.

--- a/src/core/Utils.ts
+++ b/src/core/Utils.ts
@@ -50,23 +50,24 @@ export function parseNumber(value?: null | number | string, defaultValue: number
  *
  * This method performs the following transformations to the input name:
  *
- * - If the name is empty or undefined, return the provided `fallbackSymbol`
- * - Replace all non-alphanumeric characters with dashes (consecutive characters will be replaced with a single dash)
- * - Trim leading and trailing dashes
- * - Convert to uppercase
+ * - If the name is empty or undefined, return the provided `fallbackSymbol`.
+ * - Replace all non-alphanumeric characters with dashes (consecutive characters will be replaced
+ *   with a single dash).
+ * - Trim leading and trailing dashes.
+ * - Convert to uppercase.
  *
  * @param name - The name to sanitize
  * @param fallbackSymbol - The symbol to return if the name is empty or undefined
- * @returns Sanitized symbol string
+ * @returns Sanitized symbol string or `undefined` if the name is empty and no fallback is provided
  */
-export function sanitizeName(name?: string, fallbackSymbol: string = ""): string {
+export function sanitizeName(name?: string, fallbackSymbol?: string): string | undefined {
   if (!name) {
     return fallbackSymbol;
   }
 
   const sanitized = name
-    // Replace all non-alphanumeric characters with dashes (consecutive characters will be
-    // replaced with a single dash)
+    // Replace all non-alphanumeric characters with dashes (consecutive characters will be replaced
+    // with a single dash)
     .replaceAll(/[\W_]+/g, "-");
 
   return sanitized
@@ -99,5 +100,28 @@ export function formatLoggedValue(
   label: string = "",
   emptyLabel: string = "",
 ): string {
-  return value ? `${label}${bold(value)}` : emptyLabel;
+  return value ? label + bold(value) : emptyLabel;
+}
+
+/**
+ * Format a pair of values for logging with corresponding labels
+ *
+ * Formats a pair of values with corresponding labels for logging purposes. Each value will be
+ * formatted using `formatLoggedValue` with its respective label. If both values are present, they
+ * will be separated by the specified `separator`.
+ *
+ * @param values - A pair of values to format
+ * @param labels - A pair of labels corresponding to each value
+ * @param separator - The separator to use between values if both are present (default: ", ")
+ * @returns Formatted string for logging
+ */
+export function formatPair(
+  values: [string?, string?],
+  labels: [string, string],
+  separator: string = ", ",
+): string {
+  const [value1, value2] = values;
+  const [label1, label2] = labels;
+  const sep = value1 && value2 ? separator : "";
+  return formatLoggedValue(value1, label1) + sep + formatLoggedValue(value2, label2);
 }

--- a/src/core/Utils.ts
+++ b/src/core/Utils.ts
@@ -58,9 +58,9 @@ export function parseNumber(value?: null | number | string, defaultValue: number
  *
  * @param name - The name to sanitize
  * @param fallbackSymbol - The symbol to return if the name is empty or undefined
- * @returns Sanitized symbol string or `undefined` if the name is empty and no fallback is provided
+ * @returns Sanitized symbol or empty string
  */
-export function sanitizeName(name?: string, fallbackSymbol?: string): string | undefined {
+export function sanitizeName(name?: string, fallbackSymbol: string = ""): string {
   if (!name) {
     return fallbackSymbol;
   }

--- a/src/data-providers/OverridesDataProvider.ts
+++ b/src/data-providers/OverridesDataProvider.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 
 import { bold } from "colorette";
 
-import { DataProvider, SymbolQuery } from "../core/DataProvider";
+import { DataProvider, SymbolQuery, SymbolResult } from "../core/DataProvider";
 import { Logger } from "../core/Logger";
 
 /**
@@ -41,38 +41,28 @@ export class OverridesDataProvider extends DataProvider {
    * Query for a symbol in the overrides
    *
    * @param query - Symbol query parameters
-   * @returns Symbol result or `null` if not found
+   * @returns Resolved symbol result or empty object if cannot resolve
    */
-  query(query: SymbolQuery): string | null {
+  query(query: SymbolQuery): SymbolResult {
+    let symbol: string | undefined;
+
     if (query.symbol) {
-      const symbol = this.overrides.symbols.get(query.symbol.trim().toUpperCase());
-      if (symbol) {
-        return symbol;
-      }
+      symbol = this.overrides.symbols.get(query.symbol);
     }
 
-    if (query.isin) {
-      const symbol = this.overrides.isin.get(query.isin.trim().toUpperCase());
-      if (symbol) {
-        return symbol;
-      }
+    if (!symbol && query.isin) {
+      symbol = this.overrides.isin.get(query.isin);
     }
 
-    if (query.cusip) {
-      const symbol = this.overrides.cusip.get(query.cusip.trim().toUpperCase());
-      if (symbol) {
-        return symbol;
-      }
+    if (!symbol && query.cusip) {
+      symbol = this.overrides.cusip.get(query.cusip);
     }
 
-    if (query.name) {
-      const symbol = this.overrides.names.get(query.name.trim().toUpperCase());
-      if (symbol) {
-        return symbol;
-      }
+    if (!symbol && query.name) {
+      symbol = this.overrides.names.get(query.name.toUpperCase());
     }
 
-    return null;
+    return { symbol };
   }
 }
 

--- a/src/data-providers/OverridesDataProvider.ts
+++ b/src/data-providers/OverridesDataProvider.ts
@@ -17,9 +17,17 @@ import { Logger } from "../core/Logger";
  */
 export interface Overrides {
   symbols: Map<string, string>;
-  isin: Map<string, string>;
-  cusip: Map<string, string>;
+  isins: Map<string, string>;
+  cusips: Map<string, string>;
   names: Map<string, string>;
+}
+
+/**
+ * Interface for overrides organized by type
+ */
+export interface OverridesByType {
+  symbol?: Overrides;
+  isin?: Overrides;
 }
 
 /**
@@ -27,9 +35,9 @@ export interface Overrides {
  * an INI file
  */
 export class OverridesDataProvider extends DataProvider {
-  private readonly overrides: Overrides;
+  private readonly overrides: OverridesByType;
 
-  constructor(overrides: Overrides) {
+  constructor(overrides: OverridesByType) {
     super(
       "Overrides",
       "Loads symbol overrides and ISIN, CUSIP, and company name mappings from an INI file",
@@ -44,25 +52,73 @@ export class OverridesDataProvider extends DataProvider {
    * @returns Resolved symbol result or empty object if cannot resolve
    */
   query(query: SymbolQuery): SymbolResult {
+    const isin = this.getISINFromOverrides(query);
+
+    // If ISIN was overridden, we use the override value for symbol lookup
+    const symbol = this.getSymbolFromOverrides({ ...query, isin: isin || query.isin });
+
+    return { symbol, isin };
+  }
+
+  /**
+   * Get an ISIN from the overrides
+   *
+   * The override lookup order is: ISIN, symbol, CUSIP, company name.
+   *
+   * @param query - Symbol query parameters
+   * @returns Resolved ISIN or `undefined` if cannot resolve
+   */
+  private getISINFromOverrides(query: SymbolQuery): string | undefined {
+    const isinOverrides = this.overrides.isin;
+    if (!isinOverrides) {
+      return undefined;
+    }
+
+    let isin: string | undefined;
+    if (query.isin) {
+      isin = isinOverrides.isins.get(query.isin);
+    }
+    if (!isin && query.symbol) {
+      isin = isinOverrides.symbols.get(query.symbol);
+    }
+    if (!isin && query.cusip) {
+      isin = isinOverrides.cusips.get(query.cusip);
+    }
+    if (!isin && query.name) {
+      isin = isinOverrides.names.get(query.name.toUpperCase());
+    }
+    return isin;
+  }
+
+  /**
+   * Get a symbol from the overrides
+   *
+   * The override lookup order is: symbol, `isin` parameter, ISIN from query,
+   * CUSIP, company name.
+   *
+   * @param query - Symbol query parameters
+   * @returns Resolved symbol or `undefined` if cannot resolve
+   */
+  private getSymbolFromOverrides(query: SymbolQuery): string | undefined {
+    const symbolOverrides = this.overrides.symbol;
+    if (!symbolOverrides) {
+      return undefined;
+    }
+
     let symbol: string | undefined;
-
     if (query.symbol) {
-      symbol = this.overrides.symbols.get(query.symbol);
+      symbol = symbolOverrides.symbols.get(query.symbol);
     }
-
     if (!symbol && query.isin) {
-      symbol = this.overrides.isin.get(query.isin);
+      symbol = symbolOverrides.isins.get(query.isin);
     }
-
     if (!symbol && query.cusip) {
-      symbol = this.overrides.cusip.get(query.cusip);
+      symbol = symbolOverrides.cusips.get(query.cusip);
     }
-
     if (!symbol && query.name) {
-      symbol = this.overrides.names.get(query.name.toUpperCase());
+      symbol = symbolOverrides.names.get(query.name.toUpperCase());
     }
-
-    return { symbol };
+    return symbol;
   }
 }
 
@@ -72,14 +128,7 @@ export class OverridesDataProvider extends DataProvider {
  * @param filePath - Path to the INI file
  * @returns Parsed overrides
  */
-export function parseOverridesFile(overridesPath: string): Overrides {
-  const overrides: Overrides = {
-    symbols: new Map(),
-    isin: new Map(),
-    cusip: new Map(),
-    names: new Map(),
-  };
-
+export function parseOverridesFile(overridesPath: string): OverridesByType {
   const filePath = path.resolve(overridesPath);
 
   if (!fs.existsSync(filePath)) {
@@ -89,38 +138,68 @@ export function parseOverridesFile(overridesPath: string): Overrides {
   const content = fs.readFileSync(filePath, "utf-8");
   const parsed = ini.parse(content);
 
+  const overrides: OverridesByType = {};
+  if (parsed.ISIN) {
+    overrides.isin = parseSection(parsed.ISIN as Record<string, Record<string, string>>);
+    logOverridesSummary(overrides.isin, "ISIN", overridesPath);
+  }
   if (parsed.Symbol) {
-    for (const [key, value] of Object.entries(parsed.Symbol as Record<string, string>)) {
+    overrides.symbol = parseSection(parsed.Symbol as Record<string, Record<string, string>>);
+    logOverridesSummary(overrides.symbol, "Symbol", overridesPath);
+  }
+
+  return overrides;
+}
+
+function parseSection(section: Record<string, Record<string, string>>): Overrides {
+  const overrides: Overrides = {
+    symbols: new Map(),
+    isins: new Map(),
+    cusips: new Map(),
+    names: new Map(),
+  };
+
+  if (section.Symbol) {
+    for (const [key, value] of Object.entries(section.Symbol)) {
       overrides.symbols.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
     }
   }
 
-  if (parsed.ISIN) {
-    for (const [key, value] of Object.entries(parsed.ISIN as Record<string, string>)) {
-      overrides.isin.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
+  if (section.ISIN) {
+    for (const [key, value] of Object.entries(section.ISIN)) {
+      overrides.isins.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
     }
   }
 
-  if (parsed.CUSIP) {
-    for (const [key, value] of Object.entries(parsed.CUSIP as Record<string, string>)) {
-      overrides.cusip.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
+  if (section.CUSIP) {
+    for (const [key, value] of Object.entries(section.CUSIP)) {
+      overrides.cusips.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
     }
   }
 
-  if (parsed.Name) {
-    for (const [key, value] of Object.entries(parsed.Name as Record<string, string>)) {
+  if (section.Name) {
+    for (const [key, value] of Object.entries(section.Name)) {
       overrides.names.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
     }
   }
 
+  return overrides;
+}
+
+/**
+ * Log a summary of loaded overrides to the console
+ *
+ * @param overrides - Overrides to summarize
+ * @param type - Type of overrides (e.g. "Symbol", "ISIN")
+ * @param overridesPath - Path to the overrides file for logging
+ */
+function logOverridesSummary(overrides: Overrides, type: string, overridesPath: string): void {
   const logger = Logger.getInstance();
   logger.info(
-    `Loaded ${bold(overrides.symbols.size + overrides.isin.size + overrides.cusip.size + overrides.names.size)} overrides from: ${bold(overridesPath)}`,
+    `Loaded ${bold(overrides.symbols.size + overrides.isins.size + overrides.cusips.size + overrides.names.size)} ${bold(type)} overrides from: ${bold(overridesPath)}`,
   );
   logger.info(`  Symbols: ${bold(overrides.symbols.size)}`);
-  logger.info(`  ISINs: ${bold(overrides.isin.size)}`);
-  logger.info(`  CUSIPs: ${bold(overrides.cusip.size)}`);
+  logger.info(`  ISINs: ${bold(overrides.isins.size)}`);
+  logger.info(`  CUSIPs: ${bold(overrides.cusips.size)}`);
   logger.info(`  Company names: ${bold(overrides.names.size)}`);
-
-  return overrides;
 }

--- a/src/data-providers/index.ts
+++ b/src/data-providers/index.ts
@@ -8,4 +8,9 @@
  * Import and export all available data provider plugins
  */
 
-export { Overrides, OverridesDataProvider, parseOverridesFile } from "./OverridesDataProvider";
+export {
+  Overrides,
+  OverridesByType,
+  OverridesDataProvider,
+  parseOverridesFile,
+} from "./OverridesDataProvider";

--- a/src/formats/GenericFormat.ts
+++ b/src/formats/GenericFormat.ts
@@ -119,19 +119,17 @@ export class GenericFormat extends BaseFormat {
 
       let symbol = record.symbol?.trim().toUpperCase() ?? "";
       let isin = record.isin?.trim().toUpperCase() ?? "";
-      // If symbol is empty, try to resolve it form other fields using the symbol data service
-      if (!symbol && (record.isin || record.cusip || record.companyname)) {
-        const result = symbolDataService.querySymbolWithFallback({
+      // If symbol or ISIN are empty, try to resolve from other fields using the symbol data service
+      if (
+        (!symbol && (record.isin || record.cusip || record.companyname)) ||
+        (!isin && (record.symbol || record.cusip || record.companyname))
+      ) {
+        ({ symbol, isin } = symbolDataService.querySymbolWithFallback({
+          symbol: record.symbol,
           isin: record.isin,
           cusip: record.cusip,
           name: record.companyname,
-        });
-        if (result.symbol) {
-          symbol = result.symbol;
-        }
-        if (result.isin) {
-          isin = result.isin;
-        }
+        }));
       }
 
       result.push({

--- a/src/formats/GenericFormat.ts
+++ b/src/formats/GenericFormat.ts
@@ -117,21 +117,28 @@ export class GenericFormat extends BaseFormat {
         }
       }
 
-      let symbol = (record.symbol ?? "").trim().toUpperCase();
+      let symbol = record.symbol?.trim().toUpperCase() ?? "";
+      let isin = record.isin?.trim().toUpperCase() ?? "";
       // If symbol is empty, try to resolve it form other fields using the symbol data service
       if (!symbol && (record.isin || record.cusip || record.companyname)) {
-        ({ symbol } = symbolDataService.querySymbolWithFallback({
+        const result = symbolDataService.querySymbolWithFallback({
           isin: record.isin,
           cusip: record.cusip,
           name: record.companyname,
-        }));
+        });
+        if (result.symbol) {
+          symbol = result.symbol;
+        }
+        if (result.isin) {
+          isin = result.isin;
+        }
       }
 
       result.push({
         date: record.date,
         instrumentType: this.mapInstrumentType(record.instrumenttype),
         symbol,
-        isin: record.isin?.trim().toUpperCase() ?? "",
+        isin,
         quantity,
         activityType,
         unitPrice,

--- a/src/formats/GenericFormat.ts
+++ b/src/formats/GenericFormat.ts
@@ -131,6 +131,7 @@ export class GenericFormat extends BaseFormat {
         date: record.date,
         instrumentType: this.mapInstrumentType(record.instrumenttype),
         symbol,
+        isin: record.isin?.trim().toUpperCase() ?? "",
         quantity,
         activityType,
         unitPrice,
@@ -353,7 +354,7 @@ export class GenericFormat extends BaseFormat {
       {
         name: "ISIN",
         optional: true,
-        description: "International Securities Identification Number (requires override file)",
+        description: "International Securities Identification Number",
       },
       {
         name: "CUSIP",

--- a/src/formats/LimeCoFormat.ts
+++ b/src/formats/LimeCoFormat.ts
@@ -366,10 +366,11 @@ export class LimeCoFormat extends BaseFormat {
   private updateSymbol(record: WealthfolioRecord, symbolDataService: SymbolDataService) {
     if (!this.isAssetTransaction(record)) {
       record.symbol = "";
+      record.isin = "";
       return;
     }
 
-    const { symbol } = record;
+    const { symbol, isin } = record;
     let name: string | undefined;
     if (!symbol && record.activityType === ActivityType.Dividend) {
       // Just in case, allow any printable ASCII characters in the name. So far I've only seen
@@ -388,10 +389,16 @@ export class LimeCoFormat extends BaseFormat {
 
     const result = symbolDataService.querySymbolWithFallback({
       symbol,
+      isin,
       name,
     });
 
-    record.symbol = result.symbol;
+    if (result.symbol) {
+      record.symbol = result.symbol;
+    }
+    if (result.isin) {
+      record.isin = result.isin;
+    }
   }
 
   getExpectedSchema(): ColumnSchema[] {

--- a/src/formats/LimeCoFormat.ts
+++ b/src/formats/LimeCoFormat.ts
@@ -99,6 +99,7 @@ export class LimeCoFormat extends BaseFormat {
         // examples of how options are represented in the CSV
         instrumentType: InstrumentType.Unknown,
         symbol: record.symbol,
+        isin: "",
         quantity: this.maybeMakeAbsolute(record.quantity, activityType),
         activityType,
         unitPrice: this.maybeMakeAbsolute(record.price, activityType),

--- a/src/formats/LimeCoFormat.ts
+++ b/src/formats/LimeCoFormat.ts
@@ -387,18 +387,11 @@ export class LimeCoFormat extends BaseFormat {
       return;
     }
 
-    const result = symbolDataService.querySymbolWithFallback({
+    ({ symbol: record.symbol, isin: record.isin } = symbolDataService.querySymbolWithFallback({
       symbol,
       isin,
       name,
-    });
-
-    if (result.symbol) {
-      record.symbol = result.symbol;
-    }
-    if (result.isin) {
-      record.isin = result.isin;
-    }
+    }));
   }
 
   getExpectedSchema(): ColumnSchema[] {

--- a/tests/core/BaseFormat.test.ts
+++ b/tests/core/BaseFormat.test.ts
@@ -28,9 +28,10 @@ class TestFormat extends BaseFormat {
       instrumentType: InstrumentType.Equity,
       // eslint-disable-next-line @typescript-eslint/no-base-to-string
       symbol: record.testField ? String(record.testField) : "TEST",
+      isin: "",
       quantity: 100,
       activityType: ActivityType.Buy,
-      unitPrice: 150.0,
+      unitPrice: 150,
       currency: "EUR",
       fee: 0,
       amount: 15000,

--- a/tests/core/Converter.test.ts
+++ b/tests/core/Converter.test.ts
@@ -74,9 +74,10 @@ describe("Converter", () => {
 
       // Check header
       const headers = lines[0].split(",");
-      expect(headers.length).toBe(13);
+      expect(headers.length).toBe(14);
       expect(headers).toContain("date");
       expect(headers).toContain("symbol");
+      expect(headers).toContain("isin");
       expect(headers).toContain("quantity");
       expect(headers).toContain("activityType");
       expect(headers).toContain("unitPrice");
@@ -167,6 +168,7 @@ describe("Converter", () => {
         date: new Date("2024-01-15"),
         instrumentType: InstrumentType.Equity,
         symbol: "", // Required for Buy
+        isin: "",
         quantity: 1,
         activityType: ActivityType.Buy,
         unitPrice: 10,
@@ -182,6 +184,7 @@ describe("Converter", () => {
         date: new Date("2024-01-20"),
         instrumentType: InstrumentType.Equity,
         symbol: "MSFT",
+        isin: "",
         quantity: 2,
         activityType: ActivityType.Buy,
         unitPrice: 20,
@@ -300,6 +303,7 @@ describe("Converter", () => {
           date: new Date("2024-01-15"),
           instrumentType: InstrumentType.Unknown,
           symbol: "  aapl  ",
+          isin: "",
           quantity: 100,
           activityType: ActivityType.Buy,
           unitPrice: 150.25,
@@ -387,6 +391,7 @@ describe("Converter", () => {
         date: new Date("2024-01-15"),
         instrumentType: InstrumentType.Equity,
         symbol: "AAPL",
+        isin: "",
         quantity: 1,
         activityType: ActivityType.Buy,
         unitPrice: 10.123456789,
@@ -402,6 +407,7 @@ describe("Converter", () => {
         date: new Date("2024-01-20"),
         instrumentType: InstrumentType.Equity,
         symbol: "MSFT",
+        isin: "",
         quantity: 2,
         activityType: ActivityType.Buy,
         unitPrice: 20,

--- a/tests/core/Converter.test.ts
+++ b/tests/core/Converter.test.ts
@@ -277,7 +277,7 @@ describe("Converter", () => {
       const overridesFile = path.join(tmpDir, "test-overrides.ini");
 
       // Create a temporary overrides file that maps AAPL (which exists in sample-generic.csv)
-      fs.writeFileSync(overridesFile, "[Symbol]\nAAPL=AAPL.OVERRIDE\n", "utf-8");
+      fs.writeFileSync(overridesFile, "[Symbol.Symbol]\nAAPL=AAPL.OVERRIDE\n", "utf-8");
 
       await converter.convert(inputFile, outputFile, DEFAULT_CURRENCY, undefined, overridesFile);
 
@@ -318,7 +318,7 @@ describe("Converter", () => {
       ];
 
       // Create an overrides file that doesn't contain a mapping for AAPL
-      fs.writeFileSync(overridesFile, "[Symbol]\nOTHER=MAPPED\n", "utf-8");
+      fs.writeFileSync(overridesFile, "[Symbol.Symbol]\nOTHER=MAPPED\n", "utf-8");
 
       const testFormat = new TestFormat(records);
       const customConverter = new Converter([testFormat]);
@@ -332,6 +332,44 @@ describe("Converter", () => {
       // Symbol should be normalized to AAPL (trimmed and uppercase)
       expect(content).toContain("AAPL");
       expect(content).not.toContain("  aapl  ");
+    });
+
+    it("should apply ISIN overrides when `overridesPath` is provided", async () => {
+      const overridesFile = path.join(tmpDir, "test-isin-overrides.ini");
+
+      const records: WealthfolioRecord[] = [
+        {
+          date: new Date("2024-01-15"),
+          instrumentType: InstrumentType.Unknown,
+          symbol: "AAPL",
+          isin: "US0378331005",
+          quantity: 100,
+          activityType: ActivityType.Buy,
+          unitPrice: 150.25,
+          currency: "EUR",
+          fee: 0,
+          amount: 15025,
+          fxRate: Number.NaN,
+          subtype: ActivitySubtype.None,
+          comment: "",
+          metadata: {},
+        },
+      ];
+
+      // Create an overrides file with ISIN.ISIN section only
+      fs.writeFileSync(overridesFile, "[ISIN.ISIN]\nUS0378331005=US9999999999\n", "utf-8");
+
+      const testFormat = new TestFormat(records);
+      const customConverter = new Converter([testFormat]);
+
+      const inputFile = path.join(tmpDir, "dummy-input.csv");
+      fs.writeFileSync(inputFile, "dummy,data", "utf-8");
+
+      await customConverter.convert(inputFile, outputFile, "EUR", undefined, overridesFile);
+
+      const content = fs.readFileSync(outputFile, "utf-8");
+      expect(content).toContain("US9999999999");
+      expect(content).not.toContain("US0378331005");
     });
 
     it("should throw error when explicit format name not found", async () => {

--- a/tests/core/DataProvider.test.ts
+++ b/tests/core/DataProvider.test.ts
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { DataProvider, SymbolQuery } from "../../src/core/DataProvider";
+import { DataProvider, SymbolQuery, SymbolResult } from "../../src/core/DataProvider";
 
 class TestProvider extends DataProvider {
   constructor(description?: string) {
     super("Test", description);
   }
 
-  query(_: SymbolQuery): string | null {
-    return null;
+  query(_: SymbolQuery): SymbolResult {
+    return {};
   }
 }
 

--- a/tests/core/FieldRequirements.test.ts
+++ b/tests/core/FieldRequirements.test.ts
@@ -25,6 +25,7 @@ const createRecord = (overrides: Partial<WealthfolioRecord> = {}): WealthfolioRe
     date: new Date("2024-01-15"),
     instrumentType: instrumentType ?? InstrumentType.Unknown,
     symbol: "AAPL",
+    isin: "",
     quantity: 1,
     activityType: ActivityType.Buy,
     unitPrice: 10,
@@ -164,6 +165,74 @@ describe("FieldRequirements", () => {
       }
     });
 
+    it("should require symbol or ISIN for asset transactions", () => {
+      const activityTypes: ActivityType[] = [
+        ActivityType.Buy,
+        ActivityType.Sell,
+        ActivityType.Dividend,
+        ActivityType.Split,
+      ];
+
+      for (const activityType of activityTypes) {
+        const record = createRecord({
+          activityType,
+          symbol: "",
+          isin: "",
+          amount: 100,
+        });
+
+        const result = validateRecordFieldRequirements(record);
+
+        expect(result.valid).toBe(false);
+        expect(result.invalidFields.map((field) => field.name)).toContain("symbol");
+        expect(result.invalidFields.map((field) => field.name)).toContain("isin");
+      }
+    });
+
+    it("should allow empty symbol when ISIN is provided for asset transactions", () => {
+      const activityTypes: ActivityType[] = [
+        ActivityType.Buy,
+        ActivityType.Sell,
+        ActivityType.Dividend,
+        ActivityType.Split,
+      ];
+
+      for (const activityType of activityTypes) {
+        const record = createRecord({
+          activityType,
+          symbol: "",
+          isin: "US0378331005",
+          amount: 100,
+        });
+
+        const result = validateRecordFieldRequirements(record);
+
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    it("should allow empty ISIN when symbol is provided for asset transactions", () => {
+      const activityTypes: ActivityType[] = [
+        ActivityType.Buy,
+        ActivityType.Sell,
+        ActivityType.Dividend,
+        ActivityType.Split,
+      ];
+
+      for (const activityType of activityTypes) {
+        const record = createRecord({
+          activityType,
+          symbol: "AAPL",
+          isin: "",
+          amount: 100,
+        });
+
+        const result = validateRecordFieldRequirements(record);
+
+        expect(result.valid).toBe(true);
+      }
+    });
+
     it("should allow ignored dividend unit price when subtype is not DRIP", () => {
       const record = createRecord({
         activityType: ActivityType.Dividend,
@@ -265,25 +334,37 @@ describe("FieldRequirements", () => {
         unitPrice: 10,
         amount: Number.NaN,
       });
+      const withISIN = createRecord({
+        activityType: ActivityType.TransferOut,
+        symbol: "",
+        isin: "US0378331005",
+        quantity: 1,
+        unitPrice: 10,
+        amount: Number.NaN,
+      });
       const withoutSymbol = createRecord({
         activityType: ActivityType.TransferIn,
         symbol: "",
+        isin: "",
         quantity: Number.NaN,
         unitPrice: Number.NaN,
         amount: 100,
       });
 
       const resultWithSymbol = validateRecordFieldRequirements(withSymbol);
+      const resultWithISIN = validateRecordFieldRequirements(withISIN);
       const resultWithoutSymbol = validateRecordFieldRequirements(withoutSymbol);
 
       expect(resultWithSymbol.valid).toBe(true);
+      expect(resultWithISIN.valid).toBe(true);
       expect(resultWithoutSymbol.valid).toBe(true);
     });
 
-    it("should require amount when transfer has no symbol", () => {
+    it("should require amount when transfer has both symbol and ISIN missing", () => {
       const record = createRecord({
         activityType: ActivityType.TransferOut,
         symbol: "",
+        isin: "",
         quantity: Number.NaN,
         unitPrice: Number.NaN,
         amount: Number.NaN,
@@ -295,24 +376,33 @@ describe("FieldRequirements", () => {
       expect(result.invalidFields.map((field) => field.name)).toContain("amount");
     });
 
-    it("should keep instrument type for adjustment activity when symbol is present", () => {
-      const record = createRecord({
+    it("should keep instrument type for adjustment activity when symbol or ISIN is present", () => {
+      const recordSymbol = createRecord({
         activityType: ActivityType.Adjustment,
         instrumentType: InstrumentType.Equity,
         symbol: "AAPL",
       });
+      const recordISIN = createRecord({
+        activityType: ActivityType.Adjustment,
+        instrumentType: InstrumentType.Equity,
+        isin: "US0378331005",
+      });
 
-      const result = validateRecordFieldRequirements(record, true);
+      const resultSymbol = validateRecordFieldRequirements(recordSymbol, true);
+      const resultISIN = validateRecordFieldRequirements(recordISIN, true);
 
-      expect(result.valid).toBe(true);
-      expect(record.instrumentType).toBe(InstrumentType.Equity);
+      expect(resultSymbol.valid).toBe(true);
+      expect(resultISIN.valid).toBe(true);
+      expect(recordSymbol.instrumentType).toBe(InstrumentType.Equity);
+      expect(recordISIN.instrumentType).toBe(InstrumentType.Equity);
     });
 
-    it("should ignore instrument type for adjustment activity when symbol is missing", () => {
+    it("should ignore instrument type for adjustment activity when symbol and ISIN are missing", () => {
       const record = createRecord({
         activityType: ActivityType.Adjustment,
         instrumentType: InstrumentType.Equity,
         symbol: "",
+        isin: "",
       });
 
       const result = validateRecordFieldRequirements(record, true);
@@ -321,24 +411,33 @@ describe("FieldRequirements", () => {
       expect(record.instrumentType).toBe(InstrumentType.Unknown);
     });
 
-    it("should keep instrument type for unknown activity when symbol is present", () => {
-      const record = createRecord({
+    it("should keep instrument type for unknown activity when symbol or ISIN is present", () => {
+      const recordSymbol = createRecord({
         activityType: ActivityType.Unknown,
         instrumentType: InstrumentType.Equity,
         symbol: "AAPL",
       });
+      const recordISIN = createRecord({
+        activityType: ActivityType.Unknown,
+        instrumentType: InstrumentType.Equity,
+        isin: "US0378331005",
+      });
 
-      const result = validateRecordFieldRequirements(record, true);
+      const resultSymbol = validateRecordFieldRequirements(recordSymbol, true);
+      const resultISIN = validateRecordFieldRequirements(recordISIN, true);
 
-      expect(result.valid).toBe(true);
-      expect(record.instrumentType).toBe(InstrumentType.Equity);
+      expect(resultSymbol.valid).toBe(true);
+      expect(resultISIN.valid).toBe(true);
+      expect(recordSymbol.instrumentType).toBe(InstrumentType.Equity);
+      expect(recordISIN.instrumentType).toBe(InstrumentType.Equity);
     });
 
-    it("should ignore instrument type for unknown activity when symbol is missing", () => {
+    it("should ignore instrument type for unknown activity when symbol and ISIN are missing", () => {
       const record = createRecord({
         activityType: ActivityType.Unknown,
         instrumentType: InstrumentType.Equity,
         symbol: "",
+        isin: "",
       });
 
       const result = validateRecordFieldRequirements(record, true);

--- a/tests/core/SymbolDataService.test.ts
+++ b/tests/core/SymbolDataService.test.ts
@@ -134,9 +134,13 @@ describe("SymbolDataService", () => {
       cusip: " 38259p508 ",
       name: "Google LLC",
     });
+    const nameResult = service.querySymbolWithFallback({
+      name: "Google LLC",
+    });
 
-    expect(isinResult).toEqual({ symbol: "US0378331005", provider: "Fallback" });
+    expect(isinResult).toEqual({ symbol: "", provider: "Fallback" });
     expect(cusipResult).toEqual({ symbol: "38259P508", provider: "Fallback" });
+    expect(nameResult).toEqual({ symbol: "GOOGLE-LLC", provider: "Fallback" });
   });
 
   it("should return sanitized name when no symbol, ISIN, or CUSIP are provided", () => {
@@ -183,8 +187,8 @@ describe("SymbolDataService", () => {
   it("should re-evaluate fallback cache entries after a new provider is registered", () => {
     // First provider cannot resolve — result is cached as Fallback
     service.registerProvider(new TestProvider("ProviderA", () => null));
-    expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
-      symbol: "US0378331005",
+    expect(service.querySymbolWithFallback({ cusip: "037833100" })).toEqual({
+      symbol: "037833100",
       provider: "Fallback",
     });
 
@@ -193,7 +197,7 @@ describe("SymbolDataService", () => {
     service.registerProvider(new TestProvider("ProviderB", resolverB));
 
     // The fallback cache entry must have been cleared — ProviderB should now be queried
-    expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
+    expect(service.querySymbolWithFallback({ cusip: "037833100" })).toEqual({
       symbol: "AAPL",
       provider: "ProviderB",
     });
@@ -244,11 +248,11 @@ describe("SymbolDataService", () => {
     // Provider cannot resolve — result is cached as Fallback
     const resolver = jest.fn(() => null);
     service.registerProvider(new TestProvider("ProviderA", resolver));
-    service.querySymbolWithFallback({ isin: "US0378331005" });
+    service.querySymbolWithFallback({ cusip: "037833100" });
     expect(resolver).toHaveBeenCalledTimes(1);
 
     // Direct querySymbol() should hit the Fallback cache entry and return null immediately
-    const result = service.querySymbol({ isin: "US0378331005" });
+    const result = service.querySymbol({ cusip: "037833100" });
 
     expect(result).toBeNull();
     // Still only one call from the first query
@@ -256,10 +260,10 @@ describe("SymbolDataService", () => {
 
     // querySymbolWithFallback(), on the other hand, should hit the Fallback cache entry and return
     // the result
-    const resultWithFallback = service.querySymbolWithFallback({ isin: "US0378331005" });
+    const resultWithFallback = service.querySymbolWithFallback({ cusip: "037833100" });
 
     expect(resultWithFallback).toEqual({
-      symbol: "US0378331005",
+      symbol: "037833100",
       provider: "Fallback",
     });
     // Still only one call from the first query

--- a/tests/core/SymbolDataService.test.ts
+++ b/tests/core/SymbolDataService.test.ts
@@ -106,12 +106,42 @@ describe("SymbolDataService", () => {
     expect(service.querySymbol({ symbol: "UNKNOWN" })).toBeNull();
   });
 
+  it("should return empty result in `querySymbolWithFallback()` when all fields are missing", () => {
+    expect(service.querySymbolWithFallback({})).toEqual({
+      symbol: "",
+      isin: "",
+      provider: "Fallback",
+    });
+  });
+
+  it("should return empty result in `querySymbolWithFallback()` when all fields are empty strings", () => {
+    expect(service.querySymbolWithFallback({ symbol: "", isin: "", cusip: "", name: "" })).toEqual({
+      symbol: "",
+      isin: "",
+      provider: "Fallback",
+    });
+  });
+
+  it("should return empty result in `querySymbolWithFallback()` when all fields are whitespace", () => {
+    expect(
+      service.querySymbolWithFallback({ symbol: "  ", isin: "  ", cusip: "  ", name: "  " }),
+    ).toEqual({
+      symbol: "",
+      isin: "",
+      provider: "Fallback",
+    });
+  });
+
   it("should return provider result in `querySymbolWithFallback()` when resolved", () => {
     service.registerProvider(new TestProvider("ProviderA", () => ({ symbol: "AAPL" })));
 
     const result = service.querySymbolWithFallback({ isin: "US0378331005" });
 
-    expect(result).toEqual({ symbol: "AAPL", provider: "ProviderA" });
+    expect(result).toEqual({
+      symbol: "AAPL",
+      isin: "US0378331005",
+      provider: "ProviderA",
+    });
   });
 
   it("should fallback to normalized symbol when providers do not resolve", () => {
@@ -119,7 +149,11 @@ describe("SymbolDataService", () => {
 
     const result = service.querySymbolWithFallback({ symbol: "  msft  " });
 
-    expect(result).toEqual({ symbol: "MSFT", provider: "Fallback" });
+    expect(result).toEqual({
+      symbol: "MSFT",
+      isin: "",
+      provider: "Fallback",
+    });
   });
 
   it("should fallback to ISIN when symbol is missing and ISIN is provided", () => {
@@ -127,7 +161,11 @@ describe("SymbolDataService", () => {
 
     const result = service.querySymbolWithFallback({ isin: " us0378331005 " });
 
-    expect(result).toEqual({ isin: "US0378331005", provider: "Fallback" });
+    expect(result).toEqual({
+      symbol: "",
+      isin: "US0378331005",
+      provider: "Fallback",
+    });
   });
 
   it("should fallback in priority order when both symbol and ISIN are missing", () => {
@@ -141,8 +179,16 @@ describe("SymbolDataService", () => {
       name: "Google LLC",
     });
 
-    expect(cusipResult).toEqual({ symbol: "38259P508", provider: "Fallback" });
-    expect(nameResult).toEqual({ symbol: "GOOGLE-LLC", provider: "Fallback" });
+    expect(cusipResult).toEqual({
+      symbol: "38259P508",
+      isin: "",
+      provider: "Fallback",
+    });
+    expect(nameResult).toEqual({
+      symbol: "GOOGLE-LLC",
+      isin: "",
+      provider: "Fallback",
+    });
   });
 
   it("should return sanitized name when no symbol, ISIN, or CUSIP are provided", () => {
@@ -152,7 +198,11 @@ describe("SymbolDataService", () => {
       name: "ACME, Inc. / Class-A",
     });
 
-    expect(result).toEqual({ symbol: "ACME-INC-CLASS-A", provider: "Fallback" });
+    expect(result).toEqual({
+      symbol: "ACME-INC-CLASS-A",
+      isin: "",
+      provider: "Fallback",
+    });
   });
 
   it("should return `null` from `querySymbol()` when query contains no usable fields", () => {
@@ -189,6 +239,7 @@ describe("SymbolDataService", () => {
     service.registerProvider(new TestProvider("ProviderA", () => ({})));
     expect(service.querySymbolWithFallback({ cusip: "037833100" })).toEqual({
       symbol: "037833100",
+      isin: "",
       provider: "Fallback",
     });
 
@@ -199,6 +250,7 @@ describe("SymbolDataService", () => {
     // The fallback cache entry must have been cleared — ProviderB should now be queried
     expect(service.querySymbolWithFallback({ cusip: "037833100" })).toEqual({
       symbol: "AAPL",
+      isin: "",
       provider: "ProviderB",
     });
     expect(resolverB).toHaveBeenCalledTimes(1);
@@ -216,6 +268,7 @@ describe("SymbolDataService", () => {
     service.registerProvider(new TestProvider("ProviderB", resolverB));
     expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
       symbol: "AAPL",
+      isin: "US0378331005",
       provider: "ProviderA",
     });
 
@@ -239,6 +292,7 @@ describe("SymbolDataService", () => {
     service.registerProvider(new TestProvider("ProviderB", resolverB));
     expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
       symbol: "MSFT",
+      isin: "US0378331005",
       provider: "ProviderB",
     });
     expect(resolverB).toHaveBeenCalledTimes(1);
@@ -272,6 +326,7 @@ describe("SymbolDataService", () => {
 
     expect(resultWithFallback).toEqual({
       symbol: "037833100",
+      isin: "",
       provider: "Fallback",
     });
     // Still only one call from the first query

--- a/tests/core/SymbolDataService.test.ts
+++ b/tests/core/SymbolDataService.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { DataProvider, SymbolQuery } from "../../src/core/DataProvider";
+import { DataProvider, SymbolQuery, SymbolResult } from "../../src/core/DataProvider";
 import { SymbolDataService } from "../../src/core/SymbolDataService";
 
 // Silence logging during tests
@@ -11,12 +11,12 @@ import { Logger, LogLevel } from "../../src/core/Logger";
 Logger.setLogLevel(LogLevel.ERROR);
 
 class TestProvider extends DataProvider {
-  private readonly resolver: (query: SymbolQuery) => string | null;
+  private readonly resolver: (query: SymbolQuery) => SymbolResult;
   private readonly canHandleResolver: (query: SymbolQuery) => boolean;
 
   constructor(
     name: string,
-    resolver: (query: SymbolQuery) => string | null,
+    resolver: (query: SymbolQuery) => SymbolResult,
     canHandleResolver: (query: SymbolQuery) => boolean = () => true,
     description?: string,
   ) {
@@ -25,7 +25,7 @@ class TestProvider extends DataProvider {
     this.canHandleResolver = canHandleResolver;
   }
 
-  query(query: SymbolQuery): string | null {
+  query(query: SymbolQuery): SymbolResult {
     return this.resolver(query);
   }
 
@@ -45,7 +45,7 @@ describe("SymbolDataService", () => {
     service.registerProvider(
       new TestProvider(
         "ProviderA",
-        () => null,
+        () => ({}),
         () => true,
         "first",
       ),
@@ -53,7 +53,7 @@ describe("SymbolDataService", () => {
     service.registerProvider(
       new TestProvider(
         "ProviderB",
-        () => null,
+        () => ({}),
         () => true,
         "second",
       ),
@@ -67,7 +67,7 @@ describe("SymbolDataService", () => {
   });
 
   it("should clear providers", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => null));
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
 
     service.clearProviders();
 
@@ -76,10 +76,10 @@ describe("SymbolDataService", () => {
   });
 
   it("should query providers in registration order and return first match", () => {
-    service.registerProvider(new TestProvider("First", () => "AAPL"));
-    service.registerProvider(new TestProvider("Second", () => "MSFT"));
+    service.registerProvider(new TestProvider("First", () => ({ symbol: "AAPL" })));
+    service.registerProvider(new TestProvider("Second", () => ({ symbol: "MSFT" })));
 
-    const result = service.querySymbol({ symbol: "AAPL" });
+    const result = service.querySymbol({ isin: "US0378331005" });
 
     expect(result).toEqual({ symbol: "AAPL", provider: "First" });
   });
@@ -88,11 +88,11 @@ describe("SymbolDataService", () => {
     service.registerProvider(
       new TestProvider(
         "SkipMe",
-        () => "AAPL",
+        () => ({ symbol: "AAPL" }),
         () => false,
       ),
     );
-    service.registerProvider(new TestProvider("Active", () => "MSFT"));
+    service.registerProvider(new TestProvider("Active", () => ({ symbol: "MSFT" })));
 
     const result = service.querySymbol({ symbol: "anything" });
 
@@ -100,36 +100,39 @@ describe("SymbolDataService", () => {
   });
 
   it("should return `null` when no providers resolve a symbol", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => null));
-    service.registerProvider(new TestProvider("ProviderB", () => null));
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
+    service.registerProvider(new TestProvider("ProviderB", () => ({})));
 
     expect(service.querySymbol({ symbol: "UNKNOWN" })).toBeNull();
   });
 
   it("should return provider result in `querySymbolWithFallback()` when resolved", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => "AAPL"));
+    service.registerProvider(new TestProvider("ProviderA", () => ({ symbol: "AAPL" })));
 
-    const result = service.querySymbolWithFallback({ symbol: "aapl" });
+    const result = service.querySymbolWithFallback({ isin: "US0378331005" });
 
     expect(result).toEqual({ symbol: "AAPL", provider: "ProviderA" });
   });
 
   it("should fallback to normalized symbol when providers do not resolve", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => null));
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
 
     const result = service.querySymbolWithFallback({ symbol: "  msft  " });
 
     expect(result).toEqual({ symbol: "MSFT", provider: "Fallback" });
   });
 
-  it("should fallback in priority order when symbol is missing", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => null));
+  it("should fallback to ISIN when symbol is missing and ISIN is provided", () => {
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
 
-    const isinResult = service.querySymbolWithFallback({
-      isin: " us0378331005 ",
-      cusip: "037833100",
-      name: "Apple Inc",
-    });
+    const result = service.querySymbolWithFallback({ isin: " us0378331005 " });
+
+    expect(result).toEqual({ isin: "US0378331005", provider: "Fallback" });
+  });
+
+  it("should fallback in priority order when both symbol and ISIN are missing", () => {
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
+
     const cusipResult = service.querySymbolWithFallback({
       cusip: " 38259p508 ",
       name: "Google LLC",
@@ -138,13 +141,12 @@ describe("SymbolDataService", () => {
       name: "Google LLC",
     });
 
-    expect(isinResult).toEqual({ symbol: "", provider: "Fallback" });
     expect(cusipResult).toEqual({ symbol: "38259P508", provider: "Fallback" });
     expect(nameResult).toEqual({ symbol: "GOOGLE-LLC", provider: "Fallback" });
   });
 
   it("should return sanitized name when no symbol, ISIN, or CUSIP are provided", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => null));
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
 
     const result = service.querySymbolWithFallback({
       name: "ACME, Inc. / Class-A",
@@ -153,16 +155,14 @@ describe("SymbolDataService", () => {
     expect(result).toEqual({ symbol: "ACME-INC-CLASS-A", provider: "Fallback" });
   });
 
-  it("should return empty fallback symbol when query contains no usable fields", () => {
-    service.registerProvider(new TestProvider("ProviderA", () => null));
+  it("should return `null` from `querySymbol()` when query contains no usable fields", () => {
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
 
-    const result = service.querySymbol({});
-
-    expect(result).toEqual({ symbol: "", provider: "Fallback" });
+    expect(service.querySymbol({})).toBeNull();
   });
 
   it("should call provider only once for repeated identical queries", () => {
-    const resolver = jest.fn(() => "AAPL");
+    const resolver = jest.fn(() => ({ symbol: "AAPL" }));
     service.registerProvider(new TestProvider("ProviderA", resolver));
 
     service.querySymbol({ isin: "US0378331005" });
@@ -174,7 +174,7 @@ describe("SymbolDataService", () => {
   });
 
   it("should treat queries with different whitespace and casing as identical", () => {
-    const resolver = jest.fn(() => "AAPL");
+    const resolver = jest.fn(() => ({ symbol: "AAPL" }));
     service.registerProvider(new TestProvider("ProviderA", resolver));
 
     service.querySymbolWithFallback({ symbol: "  aapl  " });
@@ -186,14 +186,14 @@ describe("SymbolDataService", () => {
 
   it("should re-evaluate fallback cache entries after a new provider is registered", () => {
     // First provider cannot resolve — result is cached as Fallback
-    service.registerProvider(new TestProvider("ProviderA", () => null));
+    service.registerProvider(new TestProvider("ProviderA", () => ({})));
     expect(service.querySymbolWithFallback({ cusip: "037833100" })).toEqual({
       symbol: "037833100",
       provider: "Fallback",
     });
 
     // Register a second provider that can resolve
-    const resolverB = jest.fn(() => "AAPL");
+    const resolverB = jest.fn(() => ({ symbol: "AAPL" }));
     service.registerProvider(new TestProvider("ProviderB", resolverB));
 
     // The fallback cache entry must have been cleared — ProviderB should now be queried
@@ -206,13 +206,13 @@ describe("SymbolDataService", () => {
 
   it("should not evict non-fallback cache entries when a new provider is registered", () => {
     // ProviderA resolves the query — result is cached as ProviderA
-    const resolverA = jest.fn(() => "AAPL");
+    const resolverA = jest.fn(() => ({ symbol: "AAPL" }));
     service.registerProvider(new TestProvider("ProviderA", resolverA));
     service.querySymbolWithFallback({ isin: "US0378331005" });
     expect(resolverA).toHaveBeenCalledTimes(1);
 
     // Register a second provider
-    const resolverB = jest.fn(() => "MSFT");
+    const resolverB = jest.fn(() => ({ symbol: "MSFT" }));
     service.registerProvider(new TestProvider("ProviderB", resolverB));
     expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
       symbol: "AAPL",
@@ -226,7 +226,7 @@ describe("SymbolDataService", () => {
 
   it("should clear the entire cache when all providers are cleared", () => {
     // ProviderA resolves and the result gets cached
-    const resolverA = jest.fn(() => "AAPL");
+    const resolverA = jest.fn(() => ({ symbol: "AAPL" }));
     service.registerProvider(new TestProvider("ProviderA", resolverA));
     service.querySymbol({ isin: "US0378331005" });
     expect(resolverA).toHaveBeenCalledTimes(1);
@@ -235,7 +235,7 @@ describe("SymbolDataService", () => {
     service.clearProviders();
 
     // Register a new provider and re-query — new provider must be called
-    const resolverB = jest.fn(() => "MSFT");
+    const resolverB = jest.fn(() => ({ symbol: "MSFT" }));
     service.registerProvider(new TestProvider("ProviderB", resolverB));
     expect(service.querySymbolWithFallback({ isin: "US0378331005" })).toEqual({
       symbol: "MSFT",
@@ -244,9 +244,17 @@ describe("SymbolDataService", () => {
     expect(resolverB).toHaveBeenCalledTimes(1);
   });
 
+  it("should strip ISIN from provider result when it matches the query ISIN", () => {
+    // Provider echoes back the same ISIN that was in the query — should be stripped
+    service.registerProvider(new TestProvider("ProviderA", (q) => ({ isin: q.isin })));
+
+    // Both symbol and isin are stripped, so no provider result
+    expect(service.querySymbol({ isin: "US0378331005" })).toBeNull();
+  });
+
   it("should return `null` from `querySymbol()` without querying providers when a Fallback cache entry exists", () => {
     // Provider cannot resolve — result is cached as Fallback
-    const resolver = jest.fn(() => null);
+    const resolver = jest.fn(() => ({}));
     service.registerProvider(new TestProvider("ProviderA", resolver));
     service.querySymbolWithFallback({ cusip: "037833100" });
     expect(resolver).toHaveBeenCalledTimes(1);

--- a/tests/core/Utils.test.ts
+++ b/tests/core/Utils.test.ts
@@ -131,7 +131,7 @@ describe("Utils", () => {
 
   describe("sanitizeName", () => {
     it("should return fallbackSymbol for undefined or empty name", () => {
-      expect(sanitizeName()).toBeUndefined();
+      expect(sanitizeName()).toBe("");
       expect(sanitizeName(undefined, "FB")).toBe("FB");
       expect(sanitizeName("", "FALLBACK")).toBe("FALLBACK");
     });

--- a/tests/core/Utils.test.ts
+++ b/tests/core/Utils.test.ts
@@ -7,6 +7,7 @@ import { bold } from "colorette";
 
 import {
   formatLoggedValue,
+  formatPair,
   parseNumber,
   roundToPrecision,
   sanitizeName,
@@ -130,7 +131,7 @@ describe("Utils", () => {
 
   describe("sanitizeName", () => {
     it("should return fallbackSymbol for undefined or empty name", () => {
-      expect(sanitizeName()).toBe("");
+      expect(sanitizeName()).toBeUndefined();
       expect(sanitizeName(undefined, "FB")).toBe("FB");
       expect(sanitizeName("", "FALLBACK")).toBe("FALLBACK");
     });
@@ -183,6 +184,34 @@ describe("Utils", () => {
     it("should return emptyLabel when value is absent", () => {
       expect(formatLoggedValue(undefined, "", "N/A")).toBe("N/A");
       expect(formatLoggedValue("", "Label: ", "missing")).toBe("missing");
+    });
+  });
+
+  describe("formatPair", () => {
+    it("should format both values with separator when both are present", () => {
+      expect(formatPair(["AAPL", "US0378331005"], ["Symbol ", "ISIN "])).toBe(
+        `Symbol ${bold("AAPL")}, ISIN ${bold("US0378331005")}`,
+      );
+    });
+
+    it("should use custom separator when both values are present", () => {
+      expect(formatPair(["AAPL", "US0378331005"], ["Symbol ", "ISIN "], " | ")).toBe(
+        `Symbol ${bold("AAPL")} | ISIN ${bold("US0378331005")}`,
+      );
+    });
+
+    it("should omit separator when only first value is present", () => {
+      expect(formatPair(["AAPL", undefined], ["Symbol ", "ISIN "])).toBe(`Symbol ${bold("AAPL")}`);
+    });
+
+    it("should omit separator when only second value is present", () => {
+      expect(formatPair([undefined, "US0378331005"], ["Symbol ", "ISIN "])).toBe(
+        `ISIN ${bold("US0378331005")}`,
+      );
+    });
+
+    it("should return empty string when both values are absent", () => {
+      expect(formatPair([undefined, undefined], ["Symbol ", "ISIN "])).toBe("");
     });
   });
 });

--- a/tests/data-providers/OverridesDataProvider.test.ts
+++ b/tests/data-providers/OverridesDataProvider.test.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 
 import { Logger, LogLevel } from "../../src/core/Logger";
 import {
-  Overrides,
+  OverridesByType,
   OverridesDataProvider,
   parseOverridesFile,
 } from "../../src/data-providers/OverridesDataProvider";
@@ -17,27 +17,29 @@ import {
 Logger.setLogLevel(LogLevel.ERROR);
 
 describe("OverridesDataProvider", () => {
-  let overrides: Overrides;
+  let overrides: OverridesByType;
   let provider: OverridesDataProvider;
 
   beforeEach(() => {
     overrides = {
-      symbols: new Map([
-        ["AAPL", "AAPL.US"],
-        ["MSFT", "MSFT.US"],
-      ]),
-      isin: new Map([
-        ["US0378331005", "AAPL.ISIN"],
-        ["US5949181045", "MSFT.ISIN"],
-      ]),
-      cusip: new Map([
-        ["037833100", "AAPL.CUSIP"],
-        ["594918104", "MSFT.CUSIP"],
-      ]),
-      names: new Map([
-        ["APPLE INC", "AAPL.NAME"],
-        ["MICROSOFT CORPORATION", "MSFT.NAME"],
-      ]),
+      symbol: {
+        symbols: new Map([
+          ["AAPL", "AAPL.US"],
+          ["MSFT", "MSFT.US"],
+        ]),
+        isins: new Map([
+          ["US0378331005", "AAPL.ISIN"],
+          ["US5949181045", "MSFT.ISIN"],
+        ]),
+        cusips: new Map([
+          ["037833100", "AAPL.CUSIP"],
+          ["594918104", "MSFT.CUSIP"],
+        ]),
+        names: new Map([
+          ["APPLE INC", "AAPL.NAME"],
+          ["MICROSOFT CORPORATION", "MSFT.NAME"],
+        ]),
+      },
     };
 
     provider = new OverridesDataProvider(overrides);
@@ -46,10 +48,6 @@ describe("OverridesDataProvider", () => {
   it("should expose provider metadata", () => {
     expect(provider.getName()).toBe("Overrides");
     expect(provider.getDescription()).toContain("INI file");
-  });
-
-  it("should resolve by symbol", () => {
-    expect(provider.query({ symbol: "AAPL" })).toEqual({ symbol: "AAPL.US" });
   });
 
   it("should resolve using various identifier types with pre-normalized inputs", () => {
@@ -98,6 +96,92 @@ describe("OverridesDataProvider", () => {
     ).toEqual({ symbol: undefined });
     expect(provider.query({})).toEqual({ symbol: undefined });
   });
+
+  it("should resolve ISIN from isin section by ISIN key", () => {
+    const isinProvider = new OverridesDataProvider({
+      isin: {
+        symbols: new Map(),
+        isins: new Map([["US0378331005", "US0378331005-OVERRIDE"]]),
+        cusips: new Map(),
+        names: new Map(),
+      },
+    });
+
+    expect(isinProvider.query({ isin: "US0378331005" })).toEqual({
+      symbol: undefined,
+      isin: "US0378331005-OVERRIDE",
+    });
+  });
+
+  it("should resolve ISIN from isin section by symbol key", () => {
+    const isinProvider = new OverridesDataProvider({
+      isin: {
+        symbols: new Map([["AAPL", "US0378331005"]]),
+        isins: new Map(),
+        cusips: new Map(),
+        names: new Map(),
+      },
+    });
+
+    expect(isinProvider.query({ symbol: "AAPL" })).toEqual({
+      symbol: undefined,
+      isin: "US0378331005",
+    });
+  });
+
+  it("should resolve both symbol and ISIN when both sections are populated", () => {
+    const combinedProvider = new OverridesDataProvider({
+      symbol: {
+        symbols: new Map([["AAPL", "AAPL.US"]]),
+        isins: new Map(),
+        cusips: new Map(),
+        names: new Map(),
+      },
+      isin: {
+        symbols: new Map([["AAPL", "US0378331005"]]),
+        isins: new Map(),
+        cusips: new Map(),
+        names: new Map(),
+      },
+    });
+
+    expect(combinedProvider.query({ symbol: "AAPL" })).toEqual({
+      symbol: "AAPL.US",
+      isin: "US0378331005",
+    });
+  });
+
+  it("should resolve ISIN from isin section by CUSIP key", () => {
+    const isinProvider = new OverridesDataProvider({
+      isin: {
+        symbols: new Map(),
+        isins: new Map(),
+        cusips: new Map([["037833100", "US0378331005"]]),
+        names: new Map(),
+      },
+    });
+
+    expect(isinProvider.query({ cusip: "037833100" })).toEqual({
+      symbol: undefined,
+      isin: "US0378331005",
+    });
+  });
+
+  it("should resolve ISIN from isin section by name key", () => {
+    const isinProvider = new OverridesDataProvider({
+      isin: {
+        symbols: new Map(),
+        isins: new Map(),
+        cusips: new Map(),
+        names: new Map([["APPLE INC", "US0378331005"]]),
+      },
+    });
+
+    expect(isinProvider.query({ name: "Apple Inc" })).toEqual({
+      symbol: undefined,
+      isin: "US0378331005",
+    });
+  });
 });
 
 describe("parseOverridesFile", () => {
@@ -111,23 +195,23 @@ describe("parseOverridesFile", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it("should parse and normalize Symbol, ISIN, CUSIP, and Name sections", () => {
+  it("should parse and normalize [Symbol.*] sections", () => {
     const iniPath = path.join(tmpDir, "overrides.ini");
 
     fs.writeFileSync(
       iniPath,
       [
-        "[Symbol]",
+        "[Symbol.Symbol]",
         " aapl = aapl.us ",
         "MsFt= msft.us",
         "",
-        "[ISIN]",
+        "[Symbol.ISIN]",
         " us0378331005 = aapl-isin ",
         "",
-        "[CUSIP]",
+        "[Symbol.CUSIP]",
         " 037833100 = aapl-cusip ",
         "",
-        "[Name]",
+        "[Symbol.Name]",
         " apple inc = aapl-name ",
         "",
       ].join("\n"),
@@ -136,23 +220,79 @@ describe("parseOverridesFile", () => {
 
     const parsed = parseOverridesFile(iniPath);
 
-    expect(parsed.symbols.get("AAPL")).toBe("AAPL.US");
-    expect(parsed.symbols.get("MSFT")).toBe("MSFT.US");
-    expect(parsed.isin.get("US0378331005")).toBe("AAPL-ISIN");
-    expect(parsed.cusip.get("037833100")).toBe("AAPL-CUSIP");
-    expect(parsed.names.get("APPLE INC")).toBe("AAPL-NAME");
+    expect(parsed.symbol).toBeDefined();
+    expect(parsed.symbol?.symbols.get("AAPL")).toBe("AAPL.US");
+    expect(parsed.symbol?.symbols.get("MSFT")).toBe("MSFT.US");
+    expect(parsed.symbol?.isins.get("US0378331005")).toBe("AAPL-ISIN");
+    expect(parsed.symbol?.cusips.get("037833100")).toBe("AAPL-CUSIP");
+    expect(parsed.symbol?.names.get("APPLE INC")).toBe("AAPL-NAME");
   });
 
-  it("should return empty maps when sections are missing", () => {
+  it("should parse and normalize [ISIN.*] sections", () => {
+    const iniPath = path.join(tmpDir, "isin-overrides.ini");
+
+    fs.writeFileSync(
+      iniPath,
+      [
+        "[ISIN.ISIN]",
+        " us0378331005 = us0378331005-new ",
+        "",
+        "[ISIN.Symbol]",
+        " aapl = us0378331005 ",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const parsed = parseOverridesFile(iniPath);
+
+    expect(parsed.isin).toBeDefined();
+    expect(parsed.isin?.isins.get("US0378331005")).toBe("US0378331005-NEW");
+    expect(parsed.isin?.symbols.get("AAPL")).toBe("US0378331005");
+    expect(parsed.symbol).toBeUndefined();
+  });
+
+  it("should parse both [Symbol.*] and [ISIN.*] sections from a single file", () => {
+    const iniPath = path.join(tmpDir, "combined-overrides.ini");
+
+    fs.writeFileSync(
+      iniPath,
+      [
+        "[Symbol.Symbol]",
+        "aapl = aapl.us",
+        "",
+        "[Symbol.ISIN]",
+        "us0378331005 = aapl-isin",
+        "",
+        "[ISIN.Symbol]",
+        "aapl = us0378331005",
+        "",
+        "[ISIN.ISIN]",
+        "us0378331005 = us0378331005-new",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const parsed = parseOverridesFile(iniPath);
+
+    expect(parsed.symbol).toBeDefined();
+    expect(parsed.symbol?.symbols.get("AAPL")).toBe("AAPL.US");
+    expect(parsed.symbol?.isins.get("US0378331005")).toBe("AAPL-ISIN");
+
+    expect(parsed.isin).toBeDefined();
+    expect(parsed.isin?.symbols.get("AAPL")).toBe("US0378331005");
+    expect(parsed.isin?.isins.get("US0378331005")).toBe("US0378331005-NEW");
+  });
+
+  it("should return undefined for symbol and isin when sections are missing", () => {
     const iniPath = path.join(tmpDir, "minimal.ini");
     fs.writeFileSync(iniPath, "[Other]\nA=B\n", "utf-8");
 
     const parsed = parseOverridesFile(iniPath);
 
-    expect(parsed.symbols.size).toBe(0);
-    expect(parsed.isin.size).toBe(0);
-    expect(parsed.cusip.size).toBe(0);
-    expect(parsed.names.size).toBe(0);
+    expect(parsed.symbol).toBeUndefined();
+    expect(parsed.isin).toBeUndefined();
   });
 
   it("should throw when overrides file does not exist", () => {

--- a/tests/data-providers/OverridesDataProvider.test.ts
+++ b/tests/data-providers/OverridesDataProvider.test.ts
@@ -49,14 +49,14 @@ describe("OverridesDataProvider", () => {
   });
 
   it("should resolve by symbol", () => {
-    expect(provider.query({ symbol: "AAPL" })).toBe("AAPL.US");
+    expect(provider.query({ symbol: "AAPL" })).toEqual({ symbol: "AAPL.US" });
   });
 
-  it("should normalize lookup keys from query fields", () => {
-    expect(provider.query({ symbol: "  msft  " })).toBe("MSFT.US");
-    expect(provider.query({ isin: "  us0378331005 " })).toBe("AAPL.ISIN");
-    expect(provider.query({ cusip: "  594918104 " })).toBe("MSFT.CUSIP");
-    expect(provider.query({ name: "  apple inc " })).toBe("AAPL.NAME");
+  it("should resolve using various identifier types with pre-normalized inputs", () => {
+    expect(provider.query({ symbol: "MSFT" })).toEqual({ symbol: "MSFT.US" });
+    expect(provider.query({ isin: "US0378331005" })).toEqual({ symbol: "AAPL.ISIN" });
+    expect(provider.query({ cusip: "594918104" })).toEqual({ symbol: "MSFT.CUSIP" });
+    expect(provider.query({ name: "APPLE INC" })).toEqual({ symbol: "AAPL.NAME" });
   });
 
   it("should prefer symbol over ISIN, CUSIP, and name", () => {
@@ -67,7 +67,7 @@ describe("OverridesDataProvider", () => {
       name: "MICROSOFT CORPORATION",
     });
 
-    expect(result).toBe("AAPL.US");
+    expect(result).toEqual({ symbol: "AAPL.US" });
   });
 
   it("should prefer ISIN over CUSIP and name when symbol is not available", () => {
@@ -77,7 +77,7 @@ describe("OverridesDataProvider", () => {
       name: "APPLE INC",
     });
 
-    expect(result).toBe("MSFT.ISIN");
+    expect(result).toEqual({ symbol: "MSFT.ISIN" });
   });
 
   it("should prefer CUSIP over name when symbol and ISIN are not available", () => {
@@ -86,17 +86,17 @@ describe("OverridesDataProvider", () => {
       name: "MICROSOFT CORPORATION",
     });
 
-    expect(result).toBe("AAPL.CUSIP");
+    expect(result).toEqual({ symbol: "AAPL.CUSIP" });
   });
 
-  it("should return null when no override is found", () => {
+  it("should return empty result when no override is found", () => {
     expect(
       provider.query({
         name: "Non Existent Inc.",
         symbol: "UNKNOWN",
       }),
-    ).toBeNull();
-    expect(provider.query({})).toBeNull();
+    ).toEqual({ symbol: undefined });
+    expect(provider.query({})).toEqual({ symbol: undefined });
   });
 });
 

--- a/tests/formats/GenericFormat.test.ts
+++ b/tests/formats/GenericFormat.test.ts
@@ -695,10 +695,12 @@ describe("Generic Format", () => {
       ];
 
       const overrides = {
-        symbols: new Map(),
-        isin: new Map([["US0378331005", "AAPL"]]),
-        cusip: new Map(),
-        names: new Map(),
+        symbol: {
+          symbols: new Map(),
+          isins: new Map([["US0378331005", "AAPL"]]),
+          cusips: new Map(),
+          names: new Map(),
+        },
       };
 
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
@@ -720,10 +722,12 @@ describe("Generic Format", () => {
       ];
 
       const overrides = {
-        symbols: new Map(),
-        isin: new Map(),
-        cusip: new Map([["037833100", "AAPL"]]),
-        names: new Map(),
+        symbol: {
+          symbols: new Map(),
+          isins: new Map(),
+          cusips: new Map([["037833100", "AAPL"]]),
+          names: new Map(),
+        },
       };
 
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
@@ -745,11 +749,13 @@ describe("Generic Format", () => {
       ];
 
       const overrides = {
-        symbols: new Map(),
-        isin: new Map(),
-        cusip: new Map(),
-        // Keys are always uppercased when loaded from an INI file
-        names: new Map([["APPLE INC.", "AAPL"]]),
+        symbol: {
+          symbols: new Map(),
+          isins: new Map(),
+          cusips: new Map(),
+          // Keys are always uppercased when loaded from an INI file
+          names: new Map([["APPLE INC.", "AAPL"]]),
+        },
       };
 
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
@@ -772,10 +778,12 @@ describe("Generic Format", () => {
       ];
 
       const overrides = {
-        symbols: new Map(),
-        isin: new Map([["US0378331005", "DIFFERENT"]]),
-        cusip: new Map(),
-        names: new Map(),
+        symbol: {
+          symbols: new Map(),
+          isins: new Map([["US0378331005", "DIFFERENT"]]),
+          cusips: new Map(),
+          names: new Map(),
+        },
       };
 
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
@@ -798,10 +806,12 @@ describe("Generic Format", () => {
       ];
 
       const overrides = {
-        symbols: new Map(),
-        isin: new Map([["US0378331005", "AAPL"]]),
-        cusip: new Map([["037833100", "CUSIP_APPLE"]]),
-        names: new Map(),
+        symbol: {
+          symbols: new Map(),
+          isins: new Map([["US0378331005", "AAPL"]]),
+          cusips: new Map([["037833100", "CUSIP_APPLE"]]),
+          names: new Map(),
+        },
       };
 
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
@@ -823,10 +833,12 @@ describe("Generic Format", () => {
       ];
 
       const overrides = {
-        symbols: new Map(),
-        isin: new Map(),
-        cusip: new Map(),
-        names: new Map(),
+        symbol: {
+          symbols: new Map(),
+          isins: new Map(),
+          cusips: new Map(),
+          names: new Map(),
+        },
       };
 
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
@@ -849,10 +861,12 @@ describe("Generic Format", () => {
       ];
 
       const overrides = {
-        symbols: new Map(),
-        isin: new Map(),
-        cusip: new Map(),
-        names: new Map(),
+        symbol: {
+          symbols: new Map(),
+          isins: new Map(),
+          cusips: new Map(),
+          names: new Map(),
+        },
       };
 
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
@@ -876,6 +890,36 @@ describe("Generic Format", () => {
       const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
 
       expect(result[0].symbol).toBe("AAPL");
+    });
+
+    it("should resolve ISIN when symbol is present but ISIN is missing", () => {
+      const records = [
+        {
+          date: new Date("2024-01-15"),
+          transactiontype: "BUY",
+          symbol: "AAPL",
+          cusip: "037833100",
+          quantity: 100,
+          unitprice: 150.25,
+          amount: 15025,
+        },
+      ];
+
+      const overrides = {
+        isin: {
+          symbols: new Map([["AAPL", "US0378331005"]]),
+          isins: new Map(),
+          cusips: new Map(),
+          names: new Map(),
+        },
+      };
+
+      symbolDataService.registerProvider(new OverridesDataProvider(overrides));
+      const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
+
+      // Symbol stays as-is; ISIN is resolved from the isin section via symbol key
+      expect(result[0].symbol).toBe("AAPL");
+      expect(result[0].isin).toBe("US0378331005");
     });
   });
 });

--- a/tests/formats/GenericFormat.test.ts
+++ b/tests/formats/GenericFormat.test.ts
@@ -732,6 +732,32 @@ describe("Generic Format", () => {
       expect(result[0].symbol).toBe("AAPL");
     });
 
+    it("should convert company name to symbol using overrides", () => {
+      const records = [
+        {
+          date: new Date("2024-01-15"),
+          transactiontype: "BUY",
+          companyname: "Apple Inc.",
+          quantity: 100,
+          unitprice: 150.25,
+          amount: 15025,
+        },
+      ];
+
+      const overrides = {
+        symbols: new Map(),
+        isin: new Map(),
+        cusip: new Map(),
+        // Keys are always uppercased when loaded from an INI file
+        names: new Map([["APPLE INC.", "AAPL"]]),
+      };
+
+      symbolDataService.registerProvider(new OverridesDataProvider(overrides));
+      const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
+
+      expect(result[0].symbol).toBe("AAPL");
+    });
+
     it("should prefer symbol over ISIN when both are present", () => {
       const records = [
         {

--- a/tests/formats/GenericFormat.test.ts
+++ b/tests/formats/GenericFormat.test.ts
@@ -170,6 +170,7 @@ describe("Generic Format", () => {
           date: new Date("2024-01-15"),
           transactiontype: "BUY",
           symbol: "aapl",
+          isin: "us0378331005",
           quantity: 100,
           unitprice: 150.25,
           amount: 15025,
@@ -179,6 +180,7 @@ describe("Generic Format", () => {
       const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
 
       expect(result[0].symbol).toBe("AAPL");
+      expect(result[0].isin).toBe("US0378331005");
     });
 
     it("should handle `NaN` values", () => {
@@ -422,8 +424,9 @@ describe("Generic Format", () => {
 
       const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
 
-      // Symbol should be taken from ISIN when symbol field is missing
-      expect(result[0].symbol).toBe("US0378331005");
+      // When symbol is missing, ISIN is kept in the isin field and symbol stays empty
+      expect(result[0].symbol).toBe("");
+      expect(result[0].isin).toBe("US0378331005");
     });
 
     it("should handle missing quantity with default 0", () => {
@@ -803,7 +806,8 @@ describe("Generic Format", () => {
       symbolDataService.registerProvider(new OverridesDataProvider(overrides));
       const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
 
-      expect(result[0].symbol).toBe("US0378331005");
+      expect(result[0].symbol).toBe("");
+      expect(result[0].isin).toBe("US0378331005");
     });
 
     it("should make CUSIP uppercase when no override is found", () => {

--- a/tests/formats/LimeCoFormat.test.ts
+++ b/tests/formats/LimeCoFormat.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { ActivitySubtype, ActivityType } from "../../src/core/BaseFormat";
+import { DataProvider, SymbolQuery, SymbolResult } from "../../src/core/DataProvider";
 import { SymbolDataService } from "../../src/core/SymbolDataService";
 import { LimeCoFormat } from "../../src/formats/LimeCoFormat";
 
@@ -812,6 +813,68 @@ describe("Lime.co Format", () => {
 
       const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe("symbol resolution", () => {
+    test("should set ISIN from provider resolution", () => {
+      class ISINProvider extends DataProvider {
+        constructor() {
+          super("ISINProvider");
+        }
+        query(_: SymbolQuery): SymbolResult {
+          return { isin: "US0378331005" };
+        }
+      }
+      symbolDataService.registerProvider(new ISINProvider());
+
+      const records = [
+        {
+          date: new Date("2024-01-15T00:00:00"),
+          description: "Buy 10 AAPL @150",
+          symbol: "AAPL",
+          direction: "buy",
+          quantity: 10,
+          price: 150,
+          fees: 0,
+          amount: 1500,
+        },
+      ];
+
+      const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
+
+      expect(result[0].symbol).toBe("AAPL");
+      expect(result[0].isin).toBe("US0378331005");
+    });
+
+    test("should set symbol and ISIN from provider resolution when symbol is empty", () => {
+      class SymbolISINProvider extends DataProvider {
+        constructor() {
+          super("SymbolISINProvider");
+        }
+        query(_: SymbolQuery): SymbolResult {
+          return { symbol: "AAPL", isin: "US0378331005" };
+        }
+      }
+      symbolDataService.registerProvider(new SymbolISINProvider());
+
+      const records = [
+        {
+          date: new Date("2024-01-15T00:00:00"),
+          description: "Qualified Dividend APPLE INC 10",
+          symbol: "",
+          direction: "deposit",
+          quantity: Number.NaN,
+          price: Number.NaN,
+          fees: Number.NaN,
+          amount: 150,
+        },
+      ];
+
+      const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
+
+      expect(result[0].symbol).toBe("AAPL");
+      expect(result[0].isin).toBe("US0378331005");
     });
   });
 


### PR DESCRIPTION
## Description

1. Add `isin` field to `WealthfolioRecord`.

2. Update the field requirements:
   - Where `symbol` field was required:
     - leave the `symbol` field as required when `isin` field is empty, else set it to optional;
     - set the `isin` field to required when `symbol` field is empty, else set it to optional.
   - Set `isin` field to optional where `symbol` field is optional.
   - Set `isin` field to ignores where `symbol` field is ignored.
   - Update all other conditions that depended on `record.symbol` to now depend on `record.symbol || record.isin`.

3. Update the Generic format plugin to fill-in the filed from the ISIN column, when present.

4. Add ISIN support to the symbol resolution:
   - The symbol resolution providers can now return ISIN as part of the symbol resolution result. ISIN can be returned together with the symbol or on its own if the symbol cannot be resolved.
   - Symbol fallback will no longer take ISIN as the value. Moreover, if ISIN with no symbol is present in the query, the fallback will not set symbol in the result.
   - Symbol is no longer set to an empty string when it can't be resolved. It is unset (`undefined`) instead.
   - Provider results are now also normalized (trimmed and uppercased) for consistency.

5. Update overrides data provider to support ISIN mapping and overrides:
   - Introduce new sections to the INI file:
     - `[ISIN.ISIN]` - contains ISIN overrides;
     - `[ISIN.Symbol]` - maps symbols to ISINs;
     - `[ISIN.CUSIP]` - maps CUSIPs to ISINs;
     - `[ISIN.Name]` - maps company names to ISINs.
   - Perform ISIN lookups before symbol lookups, which means that symbols are looked up with an already resolved or overriden ISIN.
6. **BREAKING**: Update symbol section names for consistency:
   - `[Symbol]` -> `[Symbol.Symbol]`;
   - `[ISIN]`   -> `[Symbol.ISIN]`;
   - `[CUSIP]`  -> `[Symbol.CUSIP]`;
   - `[Name]`   -> `[Symbol.Name]`.

## Related Issue

Resolves #15

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New format plugin (adds support for a new CSV format)
- [ ] New data provider (adds support for a new data source for looking up symbols, etc.)
- [x] Improvement or enhancement to existing functionality (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (project maintenance, build configuration, etc.)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CODE_OF_CONDUCT.md) and agree to abide by it
- [x] I agree that my contributions will be licensed under the **BSD 3-Clause License**
- [x] My code follows the project's [coding style and conventions](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md#contributing)
- [x] I have added [JSDoc](https://jsdoc.app/) documentation for any new functions, classes, or methods
- [x] I have updated relevant documentation (README, ChangeLog, docs/, etc.)
- [x] I have written tests for my changes
- [x] All new code has adequate test coverage
- [x] All existing tests pass locally
- [x] My commits have clear and descriptive commit messages
- [x] My commits are atomic, i.e. complete and self-contained units of change (else, meld the commits before submitting the PR)

## Additional Notes

TODO list (from #15):

- [x] Add `isin` field to `WealthfolioRecord`.
- [x] Update existing plugins to fill in the new field.
- [x] Update `SymbolDataService` to also return ISIN along the ticker symbol, when available.
- [x] Optionally, add possibility to define X to ISIN mappings and, if makes sense, ISIN overrides to the `OverridesDataProvider`.

---

By submitting this pull request, I confirm that I have read and understood the [contribution guidelines](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md) and that my contributions are my own work.
