### PR TITLE
Refactor and improve the validation logic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -104,6 +104,43 @@ Upcoming release.
   - All subsequent queries (cache hits) will be logged with the `TRACE` level to
     reduce noise in the logs.
 
+- **Data validation** - The input and output data validation logic has been
+  refactored and improved to be more consistent. It will now also validate
+  non-empty fields that can be validated (e.g., currency, ISIN):
+  - Currency codes provided to the `--default-currency` CLI option are now
+    validated against the [ISO 4217][] standard. If an invalid currency code is
+    provided, the converter will abort with an error message.
+  - ISINs from the symbol resolution results are now validated including
+    calculation of the check digit. If a provider returns an invalid ISIN, it
+    will be treated as not resolved with a warning logged.
+  - ISIN _values_ (right side of `=`) in the overrides file are now validated as
+    well. If an invalid ISIN value is provided, it will be ignored with a
+    warning. ISIN _keys_ (left side of `=`) are not validated to allow fixing
+    invalid ISINs in the input data.
+  - Output field validation now also validates optional fields. If an optional
+    field is invalid, it will be cleared with a warning.
+  - The Generic format plugin now validates ISINs and CUSIPs in the input CSV.
+    Invalid values are logged with a warning but are still used. If an invalid
+    ISIN is not corrected using overrides or symbol resolution, it will fail
+    output field validation and cause the respective transaction to be skipped
+    from the output CSV.
+  - The Generic format plugin now also validates currency codes in the input CSV
+    against the [ISO 4217][] standard. If an invalid currency code is
+    encountered, a warning will be logged and it will be replaced with the
+    default currency.
+
+  As a consequence, some validation log messages have also changed.
+
+### Fixed
+
+- **The Generic format plugin no longer aborts on unknown activity types** -
+  Previously, if the Generic format plugin encountered an unknown activity type
+  in the input CSV, it would throw an error which would abort the whole
+  conversion process. Now, it will log a warning and skip the transaction,
+  allowing the rest of the transactions to be processed.
+
+[ISO 4217]: https://www.iso.org/iso-4217-currency-codes.html
+
 ## [0.2.0] - 2026-04-09
 
 This release adds support for transaction history exported from the

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -152,3 +152,34 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
+
+---
+
+### validator.js
+
+A library of string validators and sanitizers
+
+Website: <https://github.com/validatorjs/validator.js>
+
+```text
+Copyright (c) 2018 Chris O'Hara <cohara87@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```

--- a/docs/generic-format-user-guide.md
+++ b/docs/generic-format-user-guide.md
@@ -444,18 +444,26 @@ Before importing:
 
 ## Field Validation
 
-The converter automatically validates all records based on transaction type-specific field requirements. This means:
+The converter automatically validates all records based on transaction-type-specific field requirements. Fields fall into three categories:
 
-- **Required fields** for each transaction type are checked (e.g., `Symbol` is required for `BUY` but not for `DEPOSIT`).
-- **Ignored fields** are automatically cleared (e.g., `Symbol` is cleared for cash-only activities).
-- **Invalid records** with missing required fields are filtered out and not included in the output.
-- **Warnings** are logged for any validation failures, including the record number and specific field errors.
+- **Required** — must be set and valid. Records with missing or invalid required fields are **skipped** and not included in the output.
+- **Optional** — may be absent, but must be valid if set. Records with invalid optional fields have those fields **cleared** (set to an empty value), but the record is still included in the output.
+- **Ignored** — not used for the given activity type and are automatically cleared.
 
-When a record fails validation, you'll see a warning message like:
+**Warnings** are logged for any validation failures, including the record number and the specific field errors.
+
+When a record is skipped due to an invalid required field:
 
 ```text
-Skipping record 42 due to field errors:
-  - unitPrice - Invalid value, value: NaN
+Skipping record 42 due to invalid required fields:
+  - unitPrice (required) - Empty value
+```
+
+When a record has an invalid optional field that gets cleared:
+
+```text
+Record 42 has invalid optional fields, they will be cleared:
+  - isin (optional) - Invalid value: NOT_AN_ISIN
 ```
 
 This helps you identify and fix data issues in your source CSV file.
@@ -472,7 +480,7 @@ If you need more details for troubleshooting, increase log verbosity by setting 
 
 ### Unknown Transaction Type
 
-**Error:** `Unknown transaction type: XYZ`
+**Warning:** `Skipping record N due to error: Unknown activity type: XYZ`
 
 **Solution:** Check the [Transaction Types](#transaction-types) section for supported values. Transaction type names are flexible but must match one of the documented options.
 

--- a/docs/technical-information.md
+++ b/docs/technical-information.md
@@ -52,6 +52,14 @@ This document provides technical details about the architecture, design, and imp
 **Field Requirements** (`src/core/FieldRequirements.ts`)
 
 - Validates records against activity type-specific field requirements.
+- Each field has one of three requirement levels for a given activity type:
+  - **Required** — must be set and valid; records with missing or invalid required fields are skipped.
+  - **Optional** — may be absent, but must be valid if set.
+  - **Ignored** — not used for the given activity type; automatically cleared when `clearIgnoredFields` is enabled.
+- Some requirements are **conditional** and depend on other field values at runtime. Some examples:
+  - For asset transactions: `symbol` is required only when `isin` is absent, and vice versa — at least one of the two must be set.
+  - For transfers (`TRANSFER_IN` / `TRANSFER_OUT`): when `symbol` or `isin` is set, the transfer is treated as an asset transfer and requires `quantity` and `unitPrice` to be set, while `amount` is ignored; when both `symbol` and `isin` are absent the transfer is treated as a cash transfer and requires `amount` to be set, while `quantity` and `unitPrice` are ignored.
+  - For all transactions: `instrumentType` is kept only when `symbol` or `isin` is set; otherwise it is cleared.
 - Automatically clears ignored fields based on activity type.
 - Filters out invalid records with detailed error reporting.
 
@@ -218,6 +226,7 @@ These dependencies are required for the converter to run:
 - **[Day.js](https://day.js.org/)**: Date parsing and formatting.
 - **[ini](https://github.com/npm/ini)**: INI file parsing.
 - **[NodeCSV](https://csv.js.org/)** (**csv-parse** & **csv-stringify**): CSV operations.
+- **[validator.js](https://github.com/validatorjs/validator.js)**: String validation and sanitization.
 
 I try to keep runtime dependencies lean, with no or minimal transitive dependencies, to ensure that the converter remains lightweight and easy to maintain.
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -226,6 +226,8 @@ Volkswagen AG Preferred = VOW3.DE
 
 ISIN lookups are performed before symbol lookups, which means that symbol lookups are performed with an already resolved ISIN.
 
+**Note:** Values in the `[ISIN.*]` sections are validated against the ISIN format, including calculation of the check digit. Invalid ISIN values are ignored with a warning and will not be applied during conversion. Keys in the `[*.ISIN]` sections are not validated to allow fixing invalid ISINs in the input data.
+
 This option is useful for:
 
 - Correcting ticker symbol and ISIN changes after mergers or rebranding.

--- a/examples/overrides.ini
+++ b/examples/overrides.ini
@@ -26,7 +26,10 @@
 #   [Symbol.Name]    map a company name to a symbol
 #
 # Keys are compared case-insensitively and trimmed of whitespace. Values are
-# always converted to uppercase.
+# always converted to uppercase. Values in [ISIN.*] sections are validated
+# against the ISIN format, including calculation of the check digit — invalid
+# ISIN values are ignored with a warning. Keys in [*.ISIN] sections are not
+# validated to allow fixing invalid ISINs in the input data.
 #
 # Note: [ISIN.*] mappings are applied before [Symbol.*] mappings, so if the
 # record's ISIN is overridden or mapped, the resulting ISIN is used for the

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "csv-parse": "^6.2.0",
         "csv-stringify": "^6.6.0",
         "dayjs": "^1.11.20",
-        "ini": "^6.0.0"
+        "ini": "^6.0.0",
+        "validator": "^13.15.35"
       },
       "bin": {
         "convert-to-wealthfolio": "dist/index.js"
@@ -26,6 +27,7 @@
         "@types/ini": "^4.1.1",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.13.4",
+        "@types/validator": "^13.15.10",
         "eslint": "^10.0.1",
         "eslint-plugin-yml": "^3.3.0",
         "globals": "^17.3.0",
@@ -1537,6 +1539,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6791,6 +6800,15 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "csv-parse": "^6.2.0",
     "csv-stringify": "^6.6.0",
     "dayjs": "^1.11.20",
-    "ini": "^6.0.0"
+    "ini": "^6.0.0",
+    "validator": "^13.15.35"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -61,6 +62,7 @@
     "@types/ini": "^4.1.1",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.13.4",
+    "@types/validator": "^13.15.10",
     "eslint": "^10.0.1",
     "eslint-plugin-yml": "^3.3.0",
     "globals": "^17.3.0",

--- a/src/core/Converter.ts
+++ b/src/core/Converter.ts
@@ -11,10 +11,16 @@ import { CsvError, OptionsWithColumns, parse } from "csv-parse";
 import { stringify } from "csv-stringify/sync";
 
 import { BaseFormat, WealthfolioRecord } from "./BaseFormat";
-import { validateRecordFieldRequirements } from "./FieldRequirements";
+import {
+  clearField,
+  FieldRequirementLevel,
+  FieldRequirementViolationKind,
+  FieldValidationResult,
+  validateRecordFieldRequirements,
+} from "./FieldRequirements";
 import { Logger } from "./Logger";
 import { SymbolDataService } from "./SymbolDataService";
-import { parseNumber, roundToPrecision } from "./Utils";
+import { assertUnreachable, parseNumber, roundToPrecision, stringifyForLogging } from "./Utils";
 
 import { OverridesByType, OverridesDataProvider, parseOverridesFile } from "../data-providers";
 
@@ -155,13 +161,30 @@ export class Converter {
         logger.trace(
           `Validating record ${bold(index + 1)}: ${result.valid ? green("passed") : red("failed")}`,
         );
+        let skip = false;
         if (!result.valid) {
-          logger.warn(`Skipping record ${bold(index + 1)} due to field errors:`);
+          skip = result.invalidFields.some(
+            (field) => field.requirementLevel === FieldRequirementLevel.Required,
+          );
+          if (skip) {
+            logger.warn(
+              `${bold("Skipping")} record ${italic(index + 1)} due to invalid required fields:`,
+            );
+          } else {
+            logger.warn(
+              `Record ${italic(index + 1)} has invalid optional fields, they ${bold("will be cleared")}:`,
+            );
+          }
           for (const field of result.invalidFields) {
-            logger.warn(`  - ${bold(field.name)} - ${red(field.error)}, value:`, field.value);
+            logger.warn(`  - ${formatFieldValidationResult(field)}`);
+            if (!skip && field.requirementLevel === FieldRequirementLevel.Optional) {
+              // Clear the optional invalid field
+              // WARNING: Modifies original records in-place
+              clearField(record, field.name);
+            }
           }
         }
-        return result.valid;
+        return !skip;
       });
 
     const symbolOverrides = overrides?.symbol;
@@ -174,7 +197,7 @@ export class Converter {
       convertedRecords = convertedRecords.map((record, index) => {
         const newRecord = { ...record };
         if (symbolOverrides) {
-          newRecord.symbol = this.getOverrideFor(
+          newRecord.symbol = getOverrideFor(
             newRecord.symbol,
             symbolOverrides.symbols,
             index,
@@ -182,7 +205,7 @@ export class Converter {
           );
         }
         if (isinOverrides) {
-          newRecord.isin = this.getOverrideFor(newRecord.isin, isinOverrides.isins, index, "ISIN");
+          newRecord.isin = getOverrideFor(newRecord.isin, isinOverrides.isins, index, "ISIN");
         }
         return newRecord;
       });
@@ -286,44 +309,85 @@ export class Converter {
   getRegisteredFormats(): string[] {
     return this.formatPlugins.map((p) => p.getName());
   }
+}
 
-  /**
-   * Get override value for a given key from the overrides map
-   *
-   * @param key - Original value to check for override
-   * @param overridesMap - Map of overrides to check against
-   * @param recordIndex - Index of the record being processed (for logging)
-   * @param fieldName - Name of the field being overridden (for logging)
-   * @returns Overridden value if found, otherwise the original key (possibly normalized)
-   */
-  private getOverrideFor(
-    key: string,
-    overridesMap: Map<string, string>,
-    recordIndex: number,
-    fieldName: string,
-  ): string {
-    const logger = Logger.getInstance();
+/**
+ * Get override value for a given key from the overrides map
+ *
+ * @param key - Original value to check for override
+ * @param overridesMap - Map of overrides to check against
+ * @param recordIndex - Index of the record being processed (for logging)
+ * @param fieldName - Name of the field being overridden (for logging)
+ * @returns Overridden value if found, otherwise the original key (possibly normalized)
+ */
+function getOverrideFor(
+  key: string,
+  overridesMap: Map<string, string>,
+  recordIndex: number,
+  fieldName: string,
+): string {
+  const logger = Logger.getInstance();
 
-    const normalizedKey = key.trim().toUpperCase();
-    if (!normalizedKey) {
-      logger.trace(
-        `Skipping ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold("empty")} value`,
-      );
-      return "";
-    }
-
-    const mappedValue = overridesMap.get(normalizedKey);
-    if (mappedValue) {
-      logger.debug(
-        `Overriding ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold(key)} -> ${bold(mappedValue)}`,
-      );
-      return mappedValue;
-    } else if (key !== normalizedKey) {
-      logger.info(
-        `Normalizing ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold(key)} -> ${bold(normalizedKey)}`,
-      );
-      return normalizedKey; // Normalize even if no override
-    }
-    return normalizedKey; // No change
+  const normalizedKey = key.trim().toUpperCase();
+  if (!normalizedKey) {
+    logger.trace(
+      `Skipping ${italic(fieldName)} override for record ${italic(recordIndex + 1)}: ${bold("empty")} value`,
+    );
+    return "";
   }
+
+  const mappedValue = overridesMap.get(normalizedKey);
+  if (mappedValue) {
+    logger.debug(
+      `Overriding ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold(key)} -> ${bold(mappedValue)}`,
+    );
+    return mappedValue;
+  }
+  if (key !== normalizedKey) {
+    logger.info(
+      `Normalizing ${italic(fieldName)} for record ${italic(recordIndex + 1)}: ${bold(key)} -> ${bold(normalizedKey)}`,
+    );
+  }
+  return normalizedKey; // Normalize even if no override
+}
+
+/**
+ * Format a field validation result for logging
+ *
+ * @param result - Field validation result
+ * @returns Formatted log message
+ */
+// Export to make the function testable, even though it's only used in this file for now
+export function formatFieldValidationResult(result: FieldValidationResult): string {
+  let requirementLevel = "";
+  switch (result.requirementLevel) {
+    case FieldRequirementLevel.Required:
+      requirementLevel = "required";
+      break;
+    case FieldRequirementLevel.Optional:
+      requirementLevel = "optional";
+      break;
+    case FieldRequirementLevel.Ignored:
+      requirementLevel = "ignored";
+      break;
+    default:
+      assertUnreachable(result.requirementLevel);
+  }
+
+  let errorMessage = "";
+  switch (result.violationKind) {
+    case FieldRequirementViolationKind.Valid:
+      errorMessage = green("Valid");
+      break;
+    case FieldRequirementViolationKind.Unset:
+      errorMessage = red("Empty value");
+      break;
+    case FieldRequirementViolationKind.Invalid:
+      errorMessage = red(`Invalid value: ${bold(stringifyForLogging(result.value))}`);
+      break;
+    default:
+      assertUnreachable(result.violationKind);
+  }
+
+  return `${bold(result.name)} (${italic(requirementLevel)}) - ${errorMessage}`;
 }

--- a/src/core/FieldRequirements.ts
+++ b/src/core/FieldRequirements.ts
@@ -3,50 +3,90 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import { isISIN, isISO4217 } from "validator";
+
 import { bold } from "colorette";
 
 import { ActivitySubtype, ActivityType, WealthfolioRecord } from "./BaseFormat";
 import { Logger } from "./Logger";
 
-export interface FieldValidationResult {
-  name: string;
-  value: unknown;
-  error: string;
+/**
+ * Violation kinds for field requirements
+ */
+export enum FieldRequirementViolationKind {
+  Valid,
+  Unset,
+  Invalid,
 }
 
+/**
+ * Field requirement levels
+ */
+export enum FieldRequirementLevel {
+  Required,
+  Optional,
+  Ignored,
+}
+
+/**
+ * Validation result for a single field
+ *
+ * Includes the field name, value, requirement level, and violation kind (valid, unset, or invalid).
+ */
+export interface FieldValidationResult {
+  name: keyof WealthfolioRecord;
+  value: unknown;
+  requirementLevel: FieldRequirementLevel;
+  violationKind: FieldRequirementViolationKind;
+}
+
+/**
+ * Validation result for a Wealthfolio record against the field requirements
+ *
+ * Includes a boolean indicating overall validity and an array of fields that failed the validation,
+ * along with details on the violations.
+ */
 export interface RecordValidationResult {
   valid: boolean;
   invalidFields: FieldValidationResult[];
 }
 
+/**
+ * Validates a Wealthfolio record against the field requirements
+ */
 export function validateRecordFieldRequirements(
   record: WealthfolioRecord,
   clearIgnoredFields: boolean = true,
 ): RecordValidationResult {
-  const logger = Logger.getInstance();
   const fieldRequirements = RECORD_FIELD_REQUIREMENTS[record.activityType];
   const invalidFields: FieldValidationResult[] = [];
   const ignoredFields: (keyof WealthfolioRecord)[] = [];
 
   for (const field in fieldRequirements) {
-    const requirement = fieldRequirements[field as keyof WealthfolioRecord];
-    const value = record[field as keyof WealthfolioRecord];
+    const fieldKey = field as keyof WealthfolioRecord;
+    const requirement = fieldRequirements[fieldKey];
+    const value = record[fieldKey];
     const requirementLevel = typeof requirement === "function" ? requirement(record) : requirement;
 
+    const violationKind = validateFieldValue(fieldKey, value);
     if (
-      requirementLevel === FieldRequirement.Required &&
-      !validateRequiredFieldValue(field, value)
+      // Required fields must be set and valid
+      (requirementLevel === FieldRequirementLevel.Required &&
+        violationKind !== FieldRequirementViolationKind.Valid) ||
+      // Optional fields can be unset but not invalid
+      (requirementLevel === FieldRequirementLevel.Optional &&
+        violationKind === FieldRequirementViolationKind.Invalid)
     ) {
-      logger.warn(`Required field ${bold(field)} has invalid value:`, value);
       invalidFields.push({
-        name: field,
+        name: fieldKey,
         value,
-        error: "Invalid value",
+        requirementLevel,
+        violationKind,
       });
     }
 
-    if (requirementLevel === FieldRequirement.Ignored && clearIgnoredFields) {
-      ignoredFields.push(field as keyof WealthfolioRecord);
+    if (requirementLevel === FieldRequirementLevel.Ignored && clearIgnoredFields) {
+      ignoredFields.push(fieldKey);
     }
   }
 
@@ -60,41 +100,49 @@ export function validateRecordFieldRequirements(
 }
 
 /**
- * Validates the field value of a required field, failing if it's `undefined`, `null`, empty, not a
- * finite number, or an invalid date.
+ * Validates the field value
+ *
+ * The validation will return `FieldRequirementViolationKind.Unset` for empty strings (including
+ * all-whitespace strings) and `FieldRequirementViolationKind.Invalid` for invalid values.
  *
  * @param field - The name of the field being validated
  * @param value - The value to validate
- * @returns `true` if the value is valid, `false` otherwise
+ * @returns Validation result indicating whether the value is valid, unset, or invalid
  */
-export function validateRequiredFieldValue(field: string, value: unknown): boolean {
+export function validateFieldValue(
+  field: keyof WealthfolioRecord,
+  value: unknown,
+): FieldRequirementViolationKind {
   const logger = Logger.getInstance();
   logger.trace(`Validating field ${bold(field)} with type ${bold(typeof value)} and value:`, value);
-  // TODO: Any way to check activityType and subtype enums?
   switch (typeof value) {
     case "string":
-      if (value.trim().length === 0) {
-        return false;
-      }
-      if (field === "subtype") {
-        // This will actually never fail because `None` is "" and will fail the previous
-        // validation. However, just in case we set `None` to something else in the future, we can
-        // still validate it here.
-        return (value as ActivitySubtype) !== ActivitySubtype.None;
-      }
-      return true;
+      return validateStringFieldValue(field, value);
     case "number":
-      return Number.isFinite(value);
+      if (Number.isNaN(value)) {
+        // We use NaN to indicate unset numeric fields
+        return FieldRequirementViolationKind.Unset;
+      }
+      return Number.isFinite(value)
+        ? FieldRequirementViolationKind.Valid
+        : FieldRequirementViolationKind.Invalid;
     case "object":
       if (value === null) {
-        return false;
+        // `WealthfolioRecord` has no nullable fields
+        return FieldRequirementViolationKind.Invalid;
       }
       if (value instanceof Date) {
-        // Should be a valid date
-        return !Number.isNaN(value.getTime());
+        return Number.isNaN(value.getTime())
+          ? FieldRequirementViolationKind.Invalid
+          : FieldRequirementViolationKind.Valid;
       }
       // Should not be an empty object (e.g., when metadata is required)
-      return Object.keys(value).length !== 0;
+      return Object.keys(value).length === 0
+        ? FieldRequirementViolationKind.Unset
+        : FieldRequirementViolationKind.Valid;
+    case "undefined":
+      // `WealthfolioRecord` has no optional fields
+      return FieldRequirementViolationKind.Invalid;
     // `WealthfolioRecord` has no fields of these types
     case "boolean":
     case "bigint":
@@ -102,9 +150,8 @@ export function validateRequiredFieldValue(field: string, value: unknown): boole
     case "function":
       logger.warn(`Unexpected type for field ${bold(field)}: ${bold(typeof value)}`);
     // eslint-disable-next-line no-fallthrough
-    case "undefined":
     default:
-      return false;
+      return FieldRequirementViolationKind.Invalid;
   }
 }
 
@@ -113,16 +160,27 @@ export function validateRequiredFieldValue(field: string, value: unknown): boole
  *
  * This function is meant for checking whether the activity *may* have a subtype, not whether it
  * actually has one. For example, it will always return `true` if subtype requirement is a function,
- * even if the function may return `FieldRequirement.Ignored` for some records.
+ * even if the function may return `FieldRequirementLevel.Ignored` for some records.
  *
  * @param activityType - The activity type to check
  * @returns `true` if the activity can have a subtype, `false` otherwise
  */
 export function canHaveActivitySubtype(activityType: ActivityType): boolean {
-  return RECORD_FIELD_REQUIREMENTS[activityType].subtype !== FieldRequirement.Ignored;
+  return RECORD_FIELD_REQUIREMENTS[activityType].subtype !== FieldRequirementLevel.Ignored;
 }
 
-function clearField(record: WealthfolioRecord, field: keyof WealthfolioRecord): void {
+/**
+ * Clears the value of a field in a Wealthfolio record based on its type
+ *
+ * - For string fields, sets to an empty string (`""`).
+ * - For number fields, sets to `NaN`.
+ * - For Date fields, sets to an invalid date (`new Date(NaN)`).
+ * - For object fields, sets to an empty object (`{}`).
+ *
+ * @param record - The Wealthfolio record to modify
+ * @param field - The name of the field to clear
+ */
+export function clearField(record: WealthfolioRecord, field: keyof WealthfolioRecord): void {
   switch (typeof record[field]) {
     case "string":
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -144,71 +202,107 @@ function clearField(record: WealthfolioRecord, field: keyof WealthfolioRecord): 
 }
 
 /**
+ * Validates string field values based on the field name
+ *
+ * Assumes that input values are normalized: whitespaces are trimmed; ISINs, CUSIPs, and currency
+ * codes are uppercased.
+ *
+ * @param field - The name of the field being validated
+ * @param value - The normalized string value to validate
+ * @returns Validation result indicating whether the value is valid, unset, or invalid
+ */
+function validateStringFieldValue(
+  field: keyof WealthfolioRecord,
+  value: string,
+): FieldRequirementViolationKind {
+  if (value.trim().length === 0) {
+    // All-whitespace string is considered empty / unset
+    return FieldRequirementViolationKind.Unset;
+  }
+  if (field === "subtype") {
+    // `None` will actually never reach here because it's mapped to an empty string ("") and will
+    // fail the previous validation. However, just in case `None` becomes something else in the
+    // future, we should still validate it here.
+    /* istanbul ignore next: unreachable safeguard */
+    if ((value as ActivitySubtype) === ActivitySubtype.None) {
+      return FieldRequirementViolationKind.Unset;
+    }
+    return FieldRequirementViolationKind.Valid;
+  }
+  if (field === "isin") {
+    return isISIN(value)
+      ? FieldRequirementViolationKind.Valid
+      : FieldRequirementViolationKind.Invalid;
+  }
+  if (field === "currency") {
+    return isISO4217(value)
+      ? FieldRequirementViolationKind.Valid
+      : FieldRequirementViolationKind.Invalid;
+  }
+  return FieldRequirementViolationKind.Valid;
+}
+
+/**
  * Helper function for fields that are required when ISIN is not set
  *
- * Returns `FieldRequirement.Required` if ISIN is not set, otherwise returns `FieldRequirement.Optional`.
+ * Returns `FieldRequirementLevel.Required` if ISIN is not set, otherwise returns `FieldRequirementLevel.Optional`.
  *
  * @param record - The Wealthfolio record to check
  * @returns Field requirement based on the presence of ISIN
  */
-function requiredWhenNoIsinElseOptional(record: WealthfolioRecord): FieldRequirement {
-  return record.isin ? FieldRequirement.Optional : FieldRequirement.Required;
+function requiredWhenNoIsinElseOptional(record: WealthfolioRecord): FieldRequirementLevel {
+  return record.isin ? FieldRequirementLevel.Optional : FieldRequirementLevel.Required;
 }
 
 /**
  * Helper function for fields that are required when symbol is not set
  *
- * Returns `FieldRequirement.Required` if symbol is not set, otherwise returns `FieldRequirement.Optional`.
+ * Returns `FieldRequirementLevel.Required` if symbol is not set, otherwise returns `FieldRequirementLevel.Optional`.
  *
  * @param record - The Wealthfolio record to check
  * @returns Field requirement based on the presence of symbol
  */
-function requiredWhenNoSymbolElseOptional(record: WealthfolioRecord): FieldRequirement {
-  return record.symbol ? FieldRequirement.Optional : FieldRequirement.Required;
+function requiredWhenNoSymbolElseOptional(record: WealthfolioRecord): FieldRequirementLevel {
+  return record.symbol ? FieldRequirementLevel.Optional : FieldRequirementLevel.Required;
 }
 
 /**
  * Helper function for fields that are required for asset transactions
  *
- * Returns `FieldRequirement.Required` when transaction is for an asset (symbol or ISIN is set),
- * otherwise returns `FieldRequirement.Ignored`.
+ * Returns `FieldRequirementLevel.Required` when transaction is for an asset (symbol or ISIN is set),
+ * otherwise returns `FieldRequirementLevel.Ignored`.
  *
  * @param record - The Wealthfolio record to check
  * @returns Field requirement based on the presence of symbol or ISIN
  */
-function requiredWhenAssetTransactionElseIgnored(record: WealthfolioRecord): FieldRequirement {
-  return !!record.symbol || !!record.isin ? FieldRequirement.Required : FieldRequirement.Ignored;
+function requiredWhenAssetTransactionElseIgnored(record: WealthfolioRecord): FieldRequirementLevel {
+  return !!record.symbol || !!record.isin
+    ? FieldRequirementLevel.Required
+    : FieldRequirementLevel.Ignored;
 }
 
 /**
  * Helper function for fields that are optional for asset transactions
  *
- * Returns `FieldRequirement.Optional` when transaction is for an asset (symbol or ISIN is set),
- * otherwise returns `FieldRequirement.Ignored`.
+ * Returns `FieldRequirementLevel.Optional` when transaction is for an asset (symbol or ISIN is set),
+ * otherwise returns `FieldRequirementLevel.Ignored`.
  *
  * @param record - The Wealthfolio record to check
  * @returns Field requirement based on the presence of symbol or ISIN
  */
-function optionalWhenAssetTransactionElseIgnored(record: WealthfolioRecord): FieldRequirement {
-  return !!record.symbol || !!record.isin ? FieldRequirement.Optional : FieldRequirement.Ignored;
-}
-
-/**
- * Field requirement levels in a Wealthfolio record
- */
-enum FieldRequirement {
-  Required,
-  Optional,
-  Ignored,
+function optionalWhenAssetTransactionElseIgnored(record: WealthfolioRecord): FieldRequirementLevel {
+  return !!record.symbol || !!record.isin
+    ? FieldRequirementLevel.Optional
+    : FieldRequirementLevel.Ignored;
 }
 
 /**
  * For more complex requirements, a function can be used based on the record content
  */
-type FieldRequirementFunction = (record: WealthfolioRecord) => FieldRequirement;
+type FieldRequirementFunction = (record: WealthfolioRecord) => FieldRequirementLevel;
 
 type WealthfolioRecordFieldRequirements = {
-  [key in keyof WealthfolioRecord]: FieldRequirement | FieldRequirementFunction;
+  [key in keyof WealthfolioRecord]: FieldRequirementLevel | FieldRequirementFunction;
 };
 
 // Most common requirements to avoid repetition
@@ -216,14 +310,14 @@ const COMMON_FIELD_REQUIREMENTS: Pick<
   WealthfolioRecordFieldRequirements,
   "date" | "activityType" | "fee" | "fxRate" | "subtype" | "comment" | "metadata" | "currency"
 > = {
-  date: FieldRequirement.Required,
-  activityType: FieldRequirement.Required,
-  fee: FieldRequirement.Optional,
-  fxRate: FieldRequirement.Optional,
-  subtype: FieldRequirement.Ignored, // Optional only for some activities
-  comment: FieldRequirement.Optional,
-  metadata: FieldRequirement.Optional,
-  currency: FieldRequirement.Required,
+  date: FieldRequirementLevel.Required,
+  activityType: FieldRequirementLevel.Required,
+  fee: FieldRequirementLevel.Optional,
+  fxRate: FieldRequirementLevel.Optional,
+  subtype: FieldRequirementLevel.Ignored, // Optional only for some activities
+  comment: FieldRequirementLevel.Optional,
+  metadata: FieldRequirementLevel.Optional,
+  currency: FieldRequirementLevel.Required,
 };
 
 /**
@@ -237,161 +331,161 @@ const RECORD_FIELD_REQUIREMENTS: {
 } = {
   [ActivityType.Buy]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Optional,
+    instrumentType: FieldRequirementLevel.Optional,
     symbol: requiredWhenNoIsinElseOptional,
     isin: requiredWhenNoSymbolElseOptional,
-    quantity: FieldRequirement.Required,
-    unitPrice: FieldRequirement.Required,
-    amount: FieldRequirement.Optional,
+    quantity: FieldRequirementLevel.Required,
+    unitPrice: FieldRequirementLevel.Required,
+    amount: FieldRequirementLevel.Optional,
   },
   [ActivityType.Sell]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Optional,
+    instrumentType: FieldRequirementLevel.Optional,
     symbol: requiredWhenNoIsinElseOptional,
     isin: requiredWhenNoSymbolElseOptional,
-    quantity: FieldRequirement.Required,
-    unitPrice: FieldRequirement.Required,
-    amount: FieldRequirement.Optional,
+    quantity: FieldRequirementLevel.Required,
+    unitPrice: FieldRequirementLevel.Required,
+    amount: FieldRequirementLevel.Optional,
   },
   [ActivityType.Dividend]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Optional,
+    instrumentType: FieldRequirementLevel.Optional,
     symbol: requiredWhenNoIsinElseOptional,
     isin: requiredWhenNoSymbolElseOptional,
-    quantity: FieldRequirement.Optional,
+    quantity: FieldRequirementLevel.Optional,
     unitPrice: (record) =>
       // DRIP and dividend in kind subtypes require unit price for cost basis calculation
       record.subtype === ActivitySubtype.DRIP || record.subtype === ActivitySubtype.DividendInKind
-        ? FieldRequirement.Required
-        : FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
-    subtype: FieldRequirement.Optional,
+        ? FieldRequirementLevel.Required
+        : FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
+    subtype: FieldRequirementLevel.Optional,
     metadata: (record) =>
       // Dividend in kind requires metadata with `received_asset_id` to know which asset was
       // received as dividends
       record.subtype === ActivitySubtype.DividendInKind
-        ? FieldRequirement.Required
-        : FieldRequirement.Optional,
+        ? FieldRequirementLevel.Required
+        : FieldRequirementLevel.Optional,
   },
   [ActivityType.Interest]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: optionalWhenAssetTransactionElseIgnored,
-    symbol: FieldRequirement.Optional,
-    isin: FieldRequirement.Optional,
-    quantity: FieldRequirement.Ignored,
+    symbol: FieldRequirementLevel.Optional,
+    isin: FieldRequirementLevel.Optional,
+    quantity: FieldRequirementLevel.Ignored,
     unitPrice: (record) =>
       // Staking reward subtype requires unit price (fair market value at the time of reward) for
       // cost basis calculation
       record.subtype === ActivitySubtype.StakingReward
-        ? FieldRequirement.Required
-        : FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
-    subtype: FieldRequirement.Optional,
+        ? FieldRequirementLevel.Required
+        : FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
+    subtype: FieldRequirementLevel.Optional,
   },
   [ActivityType.Deposit]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Ignored,
-    symbol: FieldRequirement.Ignored,
-    isin: FieldRequirement.Ignored,
-    quantity: FieldRequirement.Ignored,
-    unitPrice: FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
+    instrumentType: FieldRequirementLevel.Ignored,
+    symbol: FieldRequirementLevel.Ignored,
+    isin: FieldRequirementLevel.Ignored,
+    quantity: FieldRequirementLevel.Ignored,
+    unitPrice: FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
   },
   [ActivityType.Withdrawal]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Ignored,
-    symbol: FieldRequirement.Ignored,
-    isin: FieldRequirement.Ignored,
-    quantity: FieldRequirement.Ignored,
-    unitPrice: FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
+    instrumentType: FieldRequirementLevel.Ignored,
+    symbol: FieldRequirementLevel.Ignored,
+    isin: FieldRequirementLevel.Ignored,
+    quantity: FieldRequirementLevel.Ignored,
+    unitPrice: FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
   },
   [ActivityType.TransferIn]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: optionalWhenAssetTransactionElseIgnored,
-    symbol: FieldRequirement.Optional,
-    isin: FieldRequirement.Optional,
+    symbol: FieldRequirementLevel.Optional,
+    isin: FieldRequirementLevel.Optional,
     quantity: requiredWhenAssetTransactionElseIgnored,
     unitPrice: requiredWhenAssetTransactionElseIgnored,
     amount: (record) =>
-      record.symbol || record.isin ? FieldRequirement.Ignored : FieldRequirement.Required,
+      record.symbol || record.isin ? FieldRequirementLevel.Ignored : FieldRequirementLevel.Required,
   },
   [ActivityType.TransferOut]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: optionalWhenAssetTransactionElseIgnored,
-    symbol: FieldRequirement.Optional,
-    isin: FieldRequirement.Optional,
+    symbol: FieldRequirementLevel.Optional,
+    isin: FieldRequirementLevel.Optional,
     quantity: requiredWhenAssetTransactionElseIgnored,
     unitPrice: requiredWhenAssetTransactionElseIgnored,
     amount: (record) =>
-      record.symbol || record.isin ? FieldRequirement.Ignored : FieldRequirement.Required,
+      record.symbol || record.isin ? FieldRequirementLevel.Ignored : FieldRequirementLevel.Required,
   },
   [ActivityType.Fee]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Ignored,
-    symbol: FieldRequirement.Ignored,
-    isin: FieldRequirement.Ignored,
-    quantity: FieldRequirement.Ignored,
-    unitPrice: FieldRequirement.Ignored,
+    instrumentType: FieldRequirementLevel.Ignored,
+    symbol: FieldRequirementLevel.Ignored,
+    isin: FieldRequirementLevel.Ignored,
+    quantity: FieldRequirementLevel.Ignored,
+    unitPrice: FieldRequirementLevel.Ignored,
     // Amount or fee - we'll use the amount
-    fee: FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
-    subtype: FieldRequirement.Optional,
+    fee: FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
+    subtype: FieldRequirementLevel.Optional,
   },
   [ActivityType.Tax]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Ignored,
-    symbol: FieldRequirement.Ignored,
-    isin: FieldRequirement.Ignored,
-    quantity: FieldRequirement.Ignored,
-    unitPrice: FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
-    subtype: FieldRequirement.Optional,
+    instrumentType: FieldRequirementLevel.Ignored,
+    symbol: FieldRequirementLevel.Ignored,
+    isin: FieldRequirementLevel.Ignored,
+    quantity: FieldRequirementLevel.Ignored,
+    unitPrice: FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
+    subtype: FieldRequirementLevel.Optional,
   },
   [ActivityType.Split]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Optional,
+    instrumentType: FieldRequirementLevel.Optional,
     symbol: requiredWhenNoIsinElseOptional,
     isin: requiredWhenNoSymbolElseOptional,
-    quantity: FieldRequirement.Ignored,
-    unitPrice: FieldRequirement.Ignored,
-    currency: FieldRequirement.Ignored,
-    fee: FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
+    quantity: FieldRequirementLevel.Ignored,
+    unitPrice: FieldRequirementLevel.Ignored,
+    currency: FieldRequirementLevel.Ignored,
+    fee: FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
   },
   [ActivityType.Credit]: {
     ...COMMON_FIELD_REQUIREMENTS,
-    instrumentType: FieldRequirement.Ignored,
-    symbol: FieldRequirement.Ignored,
-    isin: FieldRequirement.Ignored,
-    quantity: FieldRequirement.Ignored,
-    unitPrice: FieldRequirement.Ignored,
-    amount: FieldRequirement.Required,
-    subtype: FieldRequirement.Optional,
+    instrumentType: FieldRequirementLevel.Ignored,
+    symbol: FieldRequirementLevel.Ignored,
+    isin: FieldRequirementLevel.Ignored,
+    quantity: FieldRequirementLevel.Ignored,
+    unitPrice: FieldRequirementLevel.Ignored,
+    amount: FieldRequirementLevel.Required,
+    subtype: FieldRequirementLevel.Optional,
   },
   // Documentation just states that field requirement "Varies by use case"
   [ActivityType.Adjustment]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: optionalWhenAssetTransactionElseIgnored,
-    symbol: FieldRequirement.Optional,
-    isin: FieldRequirement.Optional,
-    quantity: FieldRequirement.Optional,
-    unitPrice: FieldRequirement.Optional,
-    currency: FieldRequirement.Optional,
-    amount: FieldRequirement.Optional,
-    subtype: FieldRequirement.Optional,
+    symbol: FieldRequirementLevel.Optional,
+    isin: FieldRequirementLevel.Optional,
+    quantity: FieldRequirementLevel.Optional,
+    unitPrice: FieldRequirementLevel.Optional,
+    currency: FieldRequirementLevel.Optional,
+    amount: FieldRequirementLevel.Optional,
+    subtype: FieldRequirementLevel.Optional,
   },
   // Documentation states: "Activities imported with unrecognized types are marked as UNKNOWN and
   // flagged for review". Either ignore the whole activity or simply pass all fields through?
   [ActivityType.Unknown]: {
     ...COMMON_FIELD_REQUIREMENTS,
     instrumentType: optionalWhenAssetTransactionElseIgnored,
-    symbol: FieldRequirement.Optional,
-    isin: FieldRequirement.Optional,
-    quantity: FieldRequirement.Optional,
-    unitPrice: FieldRequirement.Optional,
-    currency: FieldRequirement.Optional,
-    amount: FieldRequirement.Optional,
-    subtype: FieldRequirement.Optional,
+    symbol: FieldRequirementLevel.Optional,
+    isin: FieldRequirementLevel.Optional,
+    quantity: FieldRequirementLevel.Optional,
+    unitPrice: FieldRequirementLevel.Optional,
+    currency: FieldRequirementLevel.Optional,
+    amount: FieldRequirementLevel.Optional,
+    subtype: FieldRequirementLevel.Optional,
   },
 };

--- a/src/core/Logger.ts
+++ b/src/core/Logger.ts
@@ -5,6 +5,8 @@
 
 import { bgRed, bold, gray, green, italic, red, reset, yellow } from "colorette";
 
+import { stringifyForLogging } from "./Utils";
+
 /**
  * Log levels enumeration
  */
@@ -24,21 +26,7 @@ function formatMessageWithArgs(message: string, args: unknown[]): string {
     return message;
   }
 
-  const argStr = args
-    .map((arg) => {
-      if (arg instanceof Date) {
-        return arg.toISOString();
-      } else if (typeof arg === "object") {
-        try {
-          return JSON.stringify(arg);
-        } catch {
-          // No-op - fallback to string coercion below
-        }
-      }
-
-      return String(arg);
-    })
-    .join(" ");
+  const argStr = args.map(stringifyForLogging).join(" ");
   return `${message} ${argStr}`;
 }
 

--- a/src/core/SymbolDataService.ts
+++ b/src/core/SymbolDataService.ts
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { bold } from "colorette";
+import { bold, red } from "colorette";
+import { isISIN } from "validator";
 
 import { DataProvider, DataProviderInfo, SymbolQuery, SymbolResult } from "./DataProvider";
 import { Logger } from "./Logger";
@@ -254,6 +255,12 @@ export class SymbolDataService {
       symbol = undefined;
     }
     if (!isin || isin === normalizedQuery.isin) {
+      isin = undefined;
+    }
+    if (isin && !isISIN(isin)) {
+      Logger.getInstance().warn(
+        `${bold("Ignoring")} ${red("invalid ISIN")} for ${this.formatQueryForLogging(normalizedQuery)} -> ${bold(isin)} (provider: ${bold(provider.getName())})`,
+      );
       isin = undefined;
     }
 

--- a/src/core/Utils.ts
+++ b/src/core/Utils.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import validator from "validator";
+
 import { bold } from "colorette";
 
 /**
@@ -70,14 +72,95 @@ export function sanitizeName(name?: string, fallbackSymbol: string = ""): string
     // with a single dash)
     .replaceAll(/[\W_]+/g, "-");
 
-  return sanitized
-    .slice(
-      // Trim leading dash (there can be only one due to the regex above)...
-      sanitized.startsWith("-") ? 1 : 0,
-      // ...and trailing dash (same here, only one possible)
-      sanitized.endsWith("-") ? -1 : undefined,
-    )
-    .toUpperCase();
+  return validator.trim(sanitized, "-").toUpperCase();
+}
+
+/**
+ * Validate a CUSIP identifier
+ *
+ * @param value - The string to validate
+ * @returns `true` if the value is a valid CUSIP, `false` otherwise
+ */
+export function isCUSIP(value: string): boolean {
+  // While I and O are discouraged in CUSIPs, they are not strictly invalid, thus included in the
+  // regex range
+  if (!/^[0-9A-Z*@#]{8}\d$/i.test(value)) {
+    return false;
+  }
+
+  const upper = value.toUpperCase();
+  let sum = 0;
+  const zeroCode = "0".codePointAt(0)!;
+  const aCode = "A".codePointAt(0)!;
+
+  for (let i = 0; i < 8; i++) {
+    const char = upper[i];
+    let v: number;
+    if (char >= "0" && char <= "9") {
+      v = char.codePointAt(0)! - zeroCode;
+    } else if (char >= "A" && char <= "Z") {
+      v = char.codePointAt(0)! - aCode + 10;
+    } else if (char === "*") {
+      v = 36;
+    } else if (char === "@") {
+      v = 37;
+    } else /* char === "#" */ {
+      v = 38;
+    }
+
+    // Double values at 1-based even positions (which are 0-based odd indices)
+    if (i % 2 === 1) {
+      v *= 2;
+    }
+
+    sum += Math.floor(v / 10) + (v % 10);
+  }
+
+  const checkDigit = (10 - (sum % 10)) % 10;
+  return checkDigit === Number.parseInt(upper[8], 10);
+}
+
+/**
+ * Stringify a value for logging purposes
+ *
+ * This function converts various types of values into a string format suitable for logging:
+ * - `undefined` is represented as `<undefined>`, and `null` as `<null>`.
+ * - Strings are returned as-is.
+ * - Dates are converted to ISO string format.
+ * - Objects are stringified using `JSON.stringify()`, with a fallback to string coercion if
+ *   stringification fails (e.g., due to circular references).
+ * - Other types are converted to strings using `String()`.
+ *
+ * @param value - The value to stringify
+ * @returns A string representation of the value for logging
+ */
+export function stringifyForLogging(value: unknown): string {
+  if (value === undefined) {
+    return "<undefined>";
+  }
+  if (value === null) {
+    return "<null>";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value instanceof Date) {
+    try {
+      return value.toISOString();
+    } catch {
+      return "<invalid date>";
+    }
+  }
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      // No-op - fallback to string coercion below
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  return String(value);
 }
 
 /**
@@ -124,4 +207,15 @@ export function formatPair(
   const [label1, label2] = labels;
   const sep = value1 && value2 ? separator : "";
   return formatLoggedValue(value1, label1) + sep + formatLoggedValue(value2, label2);
+}
+
+/**
+ * Assert that a value is of type `never`, indicating that it should be unreachable
+ *
+ * This function is used as a type guard to ensure that all possible cases have been handled in
+ * control flow, such as in a `switch` statement. If the function is called, it will throw an error
+ * indicating that an unreachable code path has been executed.
+ */
+export function assertUnreachable(_: never): never {
+  throw new Error("Value is expected to be unreachable");
 }

--- a/src/data-providers/OverridesDataProvider.ts
+++ b/src/data-providers/OverridesDataProvider.ts
@@ -7,7 +7,8 @@ import ini from "ini";
 import fs from "node:fs";
 import path from "node:path";
 
-import { bold } from "colorette";
+import { bold, red } from "colorette";
+import { isISIN } from "validator";
 
 import { DataProvider, SymbolQuery, SymbolResult } from "../core/DataProvider";
 import { Logger } from "../core/Logger";
@@ -140,7 +141,7 @@ export function parseOverridesFile(overridesPath: string): OverridesByType {
 
   const overrides: OverridesByType = {};
   if (parsed.ISIN) {
-    overrides.isin = parseSection(parsed.ISIN as Record<string, Record<string, string>>);
+    overrides.isin = parseSection(parsed.ISIN as Record<string, Record<string, string>>, isISIN);
     logOverridesSummary(overrides.isin, "ISIN", overridesPath);
   }
   if (parsed.Symbol) {
@@ -151,7 +152,17 @@ export function parseOverridesFile(overridesPath: string): OverridesByType {
   return overrides;
 }
 
-function parseSection(section: Record<string, Record<string, string>>): Overrides {
+/**
+ * Parse a section of the INI file and validate values if a validator is provided
+ *
+ * @param section - Section of the INI file to parse
+ * @param valueValidator - Optional function to validate values
+ * @returns Parsed overrides for the section
+ */
+function parseSection(
+  section: Record<string, Record<string, string>>,
+  valueValidator?: (value: string) => boolean,
+): Overrides {
   const overrides: Overrides = {
     symbols: new Map(),
     isins: new Map(),
@@ -160,29 +171,46 @@ function parseSection(section: Record<string, Record<string, string>>): Override
   };
 
   if (section.Symbol) {
-    for (const [key, value] of Object.entries(section.Symbol)) {
-      overrides.symbols.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
-    }
+    overrides.symbols = parseSubsection(section.Symbol, valueValidator);
   }
 
   if (section.ISIN) {
-    for (const [key, value] of Object.entries(section.ISIN)) {
-      overrides.isins.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
-    }
+    overrides.isins = parseSubsection(section.ISIN, valueValidator);
   }
 
   if (section.CUSIP) {
-    for (const [key, value] of Object.entries(section.CUSIP)) {
-      overrides.cusips.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
-    }
+    overrides.cusips = parseSubsection(section.CUSIP, valueValidator);
   }
 
   if (section.Name) {
-    for (const [key, value] of Object.entries(section.Name)) {
-      overrides.names.set(key.trim().toUpperCase(), String(value).trim().toUpperCase());
-    }
+    overrides.names = parseSubsection(section.Name, valueValidator);
   }
 
+  return overrides;
+}
+
+/**
+ * Parse a subsection of the INI file and validate values if a validator is provided
+ *
+ * @param section - Subsection of the INI file to parse
+ * @param valueValidator - Optional function to validate values
+ * @returns Map of parsed and validated overrides
+ */
+function parseSubsection(
+  section: Record<string, string>,
+  valueValidator?: (value: string) => boolean,
+): Map<string, string> {
+  const overrides = new Map<string, string>();
+  for (const [key, value] of Object.entries(section)) {
+    const normalizedValue = value.trim().toUpperCase();
+    if (normalizedValue && (!valueValidator || valueValidator(normalizedValue))) {
+      overrides.set(key.trim().toUpperCase(), normalizedValue);
+    } else {
+      Logger.getInstance().warn(
+        `${red("Invalid value")} for key ${bold(key)} in overrides file: ${bold(value)} - will be ${bold("ignored")}`,
+      );
+    }
+  }
   return overrides;
 }
 

--- a/src/formats/GenericFormat.ts
+++ b/src/formats/GenericFormat.ts
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { bold } from "colorette";
-
+import { bold, italic, red } from "colorette";
 import { OptionsWithColumns } from "csv-parse";
+import { isISIN, isISO4217 } from "validator";
+
 import {
   ActivitySubtype,
   ActivityType,
@@ -18,6 +19,7 @@ import {
 import { canHaveActivitySubtype } from "../core/FieldRequirements";
 import { Logger } from "../core/Logger";
 import { SymbolDataService } from "../core/SymbolDataService";
+import { isCUSIP } from "../core/Utils";
 
 interface ParsedRecord extends Record<string, unknown> {
   date: Date;
@@ -78,7 +80,15 @@ export class GenericFormat extends BaseFormat {
 
     for (let i = 0; i < records.length; i++) {
       const record = records[i];
-      const activityType = this.mapActivityType(record.transactiontype);
+      let activityType: ActivityType;
+      try {
+        activityType = this.mapActivityType(record.transactiontype);
+      } catch (error) {
+        Logger.getInstance().warn(
+          `${bold("Skipping")} record ${italic(i + 1)} due to error: ${red((error as Error).message)}`,
+        );
+        continue;
+      }
       const subtype = this.mapActivitySubtype(record, activityType);
       let quantity = record.quantity;
       let unitPrice = record.unitprice;
@@ -117,8 +127,8 @@ export class GenericFormat extends BaseFormat {
         }
       }
 
-      let symbol = record.symbol?.trim().toUpperCase() ?? "";
-      let isin = record.isin?.trim().toUpperCase() ?? "";
+      let symbol = record.symbol ?? "";
+      let isin = record.isin ?? "";
       // If symbol or ISIN are empty, try to resolve from other fields using the symbol data service
       if (
         (!symbol && (record.isin || record.cusip || record.companyname)) ||
@@ -158,7 +168,7 @@ export class GenericFormat extends BaseFormat {
     if (!type) {
       return InstrumentType.Unknown;
     }
-    switch (type.trim().toLowerCase()) {
+    switch (type.toLowerCase()) {
       case "equity":
       case "stock":
       case "etf":
@@ -197,7 +207,7 @@ export class GenericFormat extends BaseFormat {
     if (!type) {
       throw new Error("No activity type");
     }
-    switch (type.trim().toLowerCase()) {
+    switch (type.toLowerCase()) {
       case "buy":
       case "purchase":
       case "acquisition":
@@ -245,7 +255,7 @@ export class GenericFormat extends BaseFormat {
       return ActivitySubtype.None;
     }
 
-    const activitySubtype = record.transactionsubtype.trim().toLowerCase();
+    const activitySubtype = record.transactionsubtype.toLowerCase();
     if (activityType === ActivityType.Dividend) {
       switch (activitySubtype) {
         case "drip":
@@ -414,19 +424,51 @@ export class GenericFormat extends BaseFormat {
       // Trim whitespaces and convert column names to lowercase
       columns: (header: string[]) => header.map((column) => column.trim().toLowerCase()),
       cast: (value, context) => {
-        if (context.column === "date") {
-          return new Date(value.trim());
-        } else if (
-          context.column === "quantity" ||
-          context.column === "unitprice" ||
-          context.column === "fee" ||
-          context.column === "amount" ||
-          context.column === "fxrate"
-        ) {
-          return Number.parseFloat(value);
+        const logger = Logger.getInstance();
+        // csv-parse doesn't trim whitespace inside quoted fields
+        const trimmedValue = value.trim();
+        switch (context.column) {
+          case "date":
+            return new Date(trimmedValue);
+          case "quantity":
+          case "unitprice":
+          case "fee":
+          case "total":
+          case "fxrate":
+            return Number.parseFloat(trimmedValue);
+          case "symbol":
+            return trimmedValue.toUpperCase();
+          case "isin": {
+            const isin = trimmedValue.toUpperCase();
+            if (isin && !isISIN(isin)) {
+              logger.warn(
+                `${red("Invalid ISIN")} in line ${italic(context.lines)} of input file: ${bold(trimmedValue)} - check the source data or use an override to correct it`,
+              );
+            }
+            return isin;
+          }
+          case "cusip": {
+            const cusip = trimmedValue.toUpperCase();
+            if (cusip && !isCUSIP(cusip)) {
+              logger.warn(
+                `${red("Invalid CUSIP")} in line ${italic(context.lines)} of input file: ${bold(trimmedValue)} - check the source data`,
+              );
+            }
+            return cusip;
+          }
+          case "currency": {
+            const currency = trimmedValue.toUpperCase();
+            if (currency && !isISO4217(currency)) {
+              logger.warn(
+                `${red("Invalid currency code")} in line ${italic(context.lines)} of input file: ${bold(trimmedValue)} - will be replaced with the default currency`,
+              );
+              return ""; // Don't set - will be replaced with the default currency later
+            }
+            return currency;
+          }
+          default:
+            return trimmedValue;
         }
-
-        return value.trim();
       },
     };
   }

--- a/src/formats/LimeCoFormat.ts
+++ b/src/formats/LimeCoFormat.ts
@@ -108,7 +108,7 @@ export class LimeCoFormat extends BaseFormat {
         amount: this.maybeMakeAbsolute(record.amount, activityType),
         fxRate: Number.NaN, // Not applicable, as Lime.co only supports USD
         subtype: this.getActivitySubtype(record, activityType),
-        comment: record.description.trim(),
+        comment: record.description,
         metadata,
       };
 
@@ -343,11 +343,7 @@ export class LimeCoFormat extends BaseFormat {
   }
 
   private combineDescriptions(first: string, second: string): string {
-    if (first === second) {
-      return first.trim();
-    } else {
-      return `${first.trim()} / ${second.trim()}`;
-    }
+    return first === second ? first : `${first} / ${second}`;
   }
 
   private isAssetTransaction(record: WealthfolioRecord): boolean {
@@ -414,22 +410,24 @@ export class LimeCoFormat extends BaseFormat {
       from_line: 2, // Skip "sep=;" row
       columns: (header: string[]) => header.map((column) => column.trim().toLowerCase()),
       cast: (value, context) => {
+        // csv-parse doesn't trim whitespace inside quoted fields
+        const trimmedValue = value.trim();
         switch (context.column) {
           case "date":
             // All timestamps have 00:00:00 time and don't include a timezone, so we assume the US
             // stock markets closing time of 16:00 US Eastern Time
-            return dayjs.tz(value, "US/Eastern").add(16, "h").toDate();
+            return dayjs.tz(trimmedValue, "US/Eastern").add(16, "h").toDate();
           case "symbol":
-            return value.trim().toUpperCase();
+            return trimmedValue.toUpperCase();
           case "direction":
-            return value.trim().toLowerCase();
+            return trimmedValue.toLowerCase();
           case "quantity":
           case "price":
           case "fees":
           case "amount":
-            return Number.parseFloat(value) || 0;
+            return Number.parseFloat(trimmedValue);
           default:
-            return value.trim();
+            return trimmedValue;
         }
       },
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
 
 import { bold, dim, red } from "colorette";
 import { InvalidArgumentError, Option, program } from "commander";
+import { isISO4217 } from "validator";
 
 import { Converter } from "./core/Converter";
 import { Logger } from "./core/Logger";
@@ -69,9 +70,9 @@ program
       "3-letter ISO 4217 currency code to use when input CSV doesn't specify one",
     )
       .argParser((currency) => {
-        if (!/^[A-Za-z]{3}$/.test(currency)) {
+        if (!isISO4217(currency)) {
           throw new InvalidArgumentError(
-            `Invalid currency: ${currency}. Use a 3-letter ISO 4217 currency code.`,
+            `Invalid currency: ${currency}. Use a valid 3-letter ISO 4217 currency code.`,
           );
         }
         return currency.toUpperCase();

--- a/tests/core/Converter.test.ts
+++ b/tests/core/Converter.test.ts
@@ -7,6 +7,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { bold, green, italic, red } from "colorette";
+
 import {
   ActivitySubtype,
   ActivityType,
@@ -15,7 +17,12 @@ import {
   InstrumentType,
   WealthfolioRecord,
 } from "../../src/core/BaseFormat";
-import { Converter } from "../../src/core/Converter";
+import { Converter, formatFieldValidationResult } from "../../src/core/Converter";
+import {
+  FieldRequirementLevel,
+  FieldRequirementViolationKind,
+  FieldValidationResult,
+} from "../../src/core/FieldRequirements";
 import { GenericFormat } from "../../src/formats/GenericFormat";
 
 // Silence logging during tests
@@ -208,11 +215,8 @@ describe("Converter", () => {
         const content = fs.readFileSync(outputFile, "utf-8");
         const lines = content.trim().split("\n");
         expect(lines).toHaveLength(2); // header + 1 valid record
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Skipping record"));
-        expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringMatching(/symbol.+Invalid value/),
-          expect.stringMatching(""),
-        );
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(`${bold("Skipping")} record`));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/symbol.+Empty value/));
       } finally {
         warnSpy.mockRestore();
       }
@@ -357,7 +361,7 @@ describe("Converter", () => {
       ];
 
       // Create an overrides file with ISIN.ISIN section only
-      fs.writeFileSync(overridesFile, "[ISIN.ISIN]\nUS0378331005=US9999999999\n", "utf-8");
+      fs.writeFileSync(overridesFile, "[ISIN.ISIN]\nUS0378331005=US5949181045\n", "utf-8");
 
       const testFormat = new TestFormat(records);
       const customConverter = new Converter([testFormat]);
@@ -368,7 +372,7 @@ describe("Converter", () => {
       await customConverter.convert(inputFile, outputFile, "EUR", undefined, overridesFile);
 
       const content = fs.readFileSync(outputFile, "utf-8");
-      expect(content).toContain("US9999999999");
+      expect(content).toContain("US5949181045");
       expect(content).not.toContain("US0378331005");
     });
 
@@ -522,6 +526,95 @@ describe("Converter", () => {
 
       expect(formats).toBeInstanceOf(Array);
       expect(formats).toContain("Generic");
+    });
+  });
+
+  describe("formatFieldValidationResult", () => {
+    const baseResult: FieldValidationResult = {
+      name: "symbol",
+      value: "AAPL",
+      requirementLevel: FieldRequirementLevel.Required,
+      violationKind: FieldRequirementViolationKind.Valid,
+    };
+
+    it("should follow the pattern 'name (level) - message'", () => {
+      const result = formatFieldValidationResult({
+        ...baseResult,
+        requirementLevel: FieldRequirementLevel.Required,
+        violationKind: FieldRequirementViolationKind.Valid,
+      });
+      expect(result).toBe(`${bold("symbol")} (${italic("required")}) - ${green("Valid")}`);
+    });
+
+    describe("requirementLevel label", () => {
+      it("should label Required fields as 'required'", () => {
+        const result = formatFieldValidationResult({
+          ...baseResult,
+          requirementLevel: FieldRequirementLevel.Required,
+        });
+        expect(result).toContain(italic("required"));
+      });
+
+      it("should label Optional fields as 'optional'", () => {
+        const result = formatFieldValidationResult({
+          ...baseResult,
+          requirementLevel: FieldRequirementLevel.Optional,
+        });
+        expect(result).toContain(italic("optional"));
+      });
+
+      it("should label Ignored fields as 'ignored'", () => {
+        const result = formatFieldValidationResult({
+          ...baseResult,
+          requirementLevel: FieldRequirementLevel.Ignored,
+        });
+        expect(result).toContain(italic("ignored"));
+      });
+
+      it("should throw error for unknown requirement level", () => {
+        expect(() =>
+          formatFieldValidationResult({
+            ...baseResult,
+            requirementLevel: 999 as FieldRequirementLevel,
+          }),
+        ).toThrow();
+      });
+    });
+
+    describe("violationKind message", () => {
+      it("should return green 'Valid' for Valid", () => {
+        const result = formatFieldValidationResult({
+          ...baseResult,
+          violationKind: FieldRequirementViolationKind.Valid,
+        });
+        expect(result).toContain(green("Valid"));
+      });
+
+      it("should return red 'Empty value' for Unset", () => {
+        const result = formatFieldValidationResult({
+          ...baseResult,
+          violationKind: FieldRequirementViolationKind.Unset,
+        });
+        expect(result).toContain(red("Empty value"));
+      });
+
+      it("should return red 'Invalid value' with bold value for Invalid", () => {
+        const result = formatFieldValidationResult({
+          ...baseResult,
+          value: "bad-value",
+          violationKind: FieldRequirementViolationKind.Invalid,
+        });
+        expect(result).toContain(red(`Invalid value: ${bold("bad-value")}`));
+      });
+
+      it("should throw error for unknown violation kind", () => {
+        expect(() =>
+          formatFieldValidationResult({
+            ...baseResult,
+            violationKind: 999 as FieldRequirementViolationKind,
+          }),
+        ).toThrow();
+      });
     });
   });
 });

--- a/tests/core/FieldRequirements.test.ts
+++ b/tests/core/FieldRequirements.test.ts
@@ -10,8 +10,9 @@ import {
   WealthfolioRecord,
 } from "../../src/core/BaseFormat";
 import {
+  FieldRequirementViolationKind,
+  validateFieldValue,
   validateRecordFieldRequirements,
-  validateRequiredFieldValue,
 } from "../../src/core/FieldRequirements";
 
 // Silence logging during tests
@@ -41,35 +42,56 @@ const createRecord = (overrides: Partial<WealthfolioRecord> = {}): WealthfolioRe
 };
 
 describe("FieldRequirements", () => {
-  describe("validateRequiredFieldValue", () => {
+  describe("validateFieldValue", () => {
     it("should validate string values", () => {
-      expect(validateRequiredFieldValue("symbol", "AAPL")).toBe(true);
-      expect(validateRequiredFieldValue("symbol", "")).toBe(false);
-      expect(validateRequiredFieldValue("subtype", ActivitySubtype.None)).toBe(false);
-      expect(validateRequiredFieldValue("subtype", ActivitySubtype.DRIP)).toBe(true);
+      expect(validateFieldValue("symbol", "AAPL")).toBe(FieldRequirementViolationKind.Valid);
+      expect(validateFieldValue("symbol", "")).toBe(FieldRequirementViolationKind.Unset);
+      expect(validateFieldValue("subtype", ActivitySubtype.None)).toBe(
+        FieldRequirementViolationKind.Unset,
+      );
+      expect(validateFieldValue("subtype", ActivitySubtype.DRIP)).toBe(
+        FieldRequirementViolationKind.Valid,
+      );
+      expect(validateFieldValue("isin", "US0378331005")).toBe(FieldRequirementViolationKind.Valid);
+      expect(validateFieldValue("isin", "NOTANISIN")).toBe(FieldRequirementViolationKind.Invalid);
+      expect(validateFieldValue("isin", "")).toBe(FieldRequirementViolationKind.Unset);
+      expect(validateFieldValue("currency", "USD")).toBe(FieldRequirementViolationKind.Valid);
+      expect(validateFieldValue("currency", "NOTACURRENCY")).toBe(
+        FieldRequirementViolationKind.Invalid,
+      );
     });
 
     it("should validate number values", () => {
-      expect(validateRequiredFieldValue("amount", 1)).toBe(true);
-      expect(validateRequiredFieldValue("amount", Number.NaN)).toBe(false);
-      expect(validateRequiredFieldValue("amount", Infinity)).toBe(false);
+      expect(validateFieldValue("amount", 1)).toBe(FieldRequirementViolationKind.Valid);
+      expect(validateFieldValue("amount", Number.NaN)).toBe(FieldRequirementViolationKind.Unset);
+      expect(validateFieldValue("amount", Infinity)).toBe(FieldRequirementViolationKind.Invalid);
+    });
+
+    it("should return Invalid for undefined values", () => {
+      expect(validateFieldValue("amount", undefined)).toBe(FieldRequirementViolationKind.Invalid);
     });
 
     it("should validate object values", () => {
-      expect(validateRequiredFieldValue("date", new Date("2024-01-15"))).toBe(true);
-      expect(validateRequiredFieldValue("date", new Date(Number.NaN))).toBe(false);
-      expect(validateRequiredFieldValue("metadata", null)).toBe(false);
-      expect(validateRequiredFieldValue("metadata", {})).toBe(false);
-      expect(validateRequiredFieldValue("metadata", { source: { broker: "Schwab" } })).toBe(true);
+      expect(validateFieldValue("date", new Date("2024-01-15"))).toBe(
+        FieldRequirementViolationKind.Valid,
+      );
+      expect(validateFieldValue("date", new Date(Number.NaN))).toBe(
+        FieldRequirementViolationKind.Invalid,
+      );
+      expect(validateFieldValue("metadata", null)).toBe(FieldRequirementViolationKind.Invalid);
+      expect(validateFieldValue("metadata", {})).toBe(FieldRequirementViolationKind.Unset);
+      expect(validateFieldValue("metadata", { source: { broker: "Schwab" } })).toBe(
+        FieldRequirementViolationKind.Valid,
+      );
     });
 
     it("should warn on unexpected types", () => {
       const warnSpy = jest.spyOn(Logger.getInstance(), "warn").mockImplementation(() => undefined);
 
       try {
-        expect(validateRequiredFieldValue("amount", true)).toBe(false);
-        expect(validateRequiredFieldValue("amount", undefined)).toBe(false);
-        expect(warnSpy).toHaveBeenCalled();
+        expect(validateFieldValue("amount", true)).toBe(FieldRequirementViolationKind.Invalid);
+        expect(validateFieldValue("amount", () => {})).toBe(FieldRequirementViolationKind.Invalid);
+        expect(warnSpy).toHaveBeenCalledTimes(2);
       } finally {
         warnSpy.mockRestore();
       }
@@ -150,19 +172,12 @@ describe("FieldRequirements", () => {
         amount: 2,
       });
 
-      const warnSpy = jest.spyOn(Logger.getInstance(), "warn").mockImplementation(() => undefined);
+      const result = validateRecordFieldRequirements(record);
 
-      try {
-        const result = validateRecordFieldRequirements(record);
-
-        expect(result.valid).toBe(false);
-        expect(result.invalidFields.map((field) => field.name)).toEqual(
-          expect.arrayContaining(["unitPrice", "metadata"]),
-        );
-        expect(warnSpy).toHaveBeenCalled();
-      } finally {
-        warnSpy.mockRestore();
-      }
+      expect(result.valid).toBe(false);
+      expect(result.invalidFields.map((field) => field.name)).toEqual(
+        expect.arrayContaining(["unitPrice", "metadata"]),
+      );
     });
 
     it("should require symbol or ISIN for asset transactions", () => {

--- a/tests/core/Logger.test.ts
+++ b/tests/core/Logger.test.ts
@@ -426,7 +426,7 @@ describe("Logger", () => {
       logger.info("Values:", null, undefined);
 
       expect(stderrSpy).toHaveBeenCalledTimes(1);
-      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Values: null undefined"));
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("Values: <null> <undefined>"));
     });
   });
 

--- a/tests/core/SymbolDataService.test.ts
+++ b/tests/core/SymbolDataService.test.ts
@@ -306,6 +306,19 @@ describe("SymbolDataService", () => {
     expect(service.querySymbol({ isin: "US0378331005" })).toBeNull();
   });
 
+  it("should ignore invalid ISIN value returned by a provider", () => {
+    service.registerProvider(
+      new TestProvider("ProviderA", () => ({ symbol: "AAPL", isin: "NOTANISIN" })),
+    );
+
+    const result = service.querySymbol({ isin: "US0378331005" });
+
+    // Symbol is kept but invalid ISIN is discarded
+    expect(result).not.toBeNull();
+    expect(result?.symbol).toBe("AAPL");
+    expect(result?.isin).toBeUndefined();
+  });
+
   it("should return `null` from `querySymbol()` without querying providers when a Fallback cache entry exists", () => {
     // Provider cannot resolve — result is cached as Fallback
     const resolver = jest.fn(() => ({}));

--- a/tests/core/Utils.test.ts
+++ b/tests/core/Utils.test.ts
@@ -8,9 +8,11 @@ import { bold } from "colorette";
 import {
   formatLoggedValue,
   formatPair,
+  isCUSIP,
   parseNumber,
   roundToPrecision,
   sanitizeName,
+  stringifyForLogging,
 } from "../../src/core/Utils";
 
 describe("Utils", () => {
@@ -212,6 +214,81 @@ describe("Utils", () => {
 
     it("should return empty string when both values are absent", () => {
       expect(formatPair([undefined, undefined], ["Symbol ", "ISIN "])).toBe("");
+    });
+  });
+
+  describe("isCUSIP", () => {
+    it("should return `true` for valid CUSIPs", () => {
+      expect(isCUSIP("037833100")).toBe(true);
+      expect(isCUSIP("38259P508")).toBe(true);
+    });
+
+    it("should be case-insensitive", () => {
+      expect(isCUSIP("30303M102")).toBe(true);
+      expect(isCUSIP("30303m102")).toBe(true);
+    });
+
+    it("should return `false` when the check digit is wrong", () => {
+      expect(isCUSIP("037833101")).toBe(false); // Apple with wrong check digit
+      expect(isCUSIP("594918100")).toBe(false); // Microsoft with wrong check digit
+    });
+
+    it("should return `false` for incorrect length", () => {
+      expect(isCUSIP("")).toBe(false);
+      expect(isCUSIP("03783310")).toBe(false); // 8 chars
+      expect(isCUSIP("0378331001")).toBe(false); // 10 chars
+    });
+
+    it("should return `false` for values with invalid characters", () => {
+      expect(isCUSIP("03783310!")).toBe(false);
+      expect(isCUSIP("03783310 ")).toBe(false);
+      expect(isCUSIP("037-33100")).toBe(false);
+      expect(isCUSIP("03783310Z")).toBe(false);
+    });
+
+    it("should accept special characters: *, @, #", () => {
+      expect(isCUSIP("000*@#008")).toBe(true);
+      expect(isCUSIP("000*@#000")).toBe(false);
+    });
+  });
+
+  describe("stringifyForLogging", () => {
+    it("should return '<undefined>' for undefined", () => {
+      expect(stringifyForLogging(undefined)).toBe("<undefined>");
+    });
+
+    it("should return '<null>' for null", () => {
+      expect(stringifyForLogging(null)).toBe("<null>");
+    });
+
+    it("should return the string as-is for strings", () => {
+      expect(stringifyForLogging("hello")).toBe("hello");
+      expect(stringifyForLogging("")).toBe("");
+    });
+
+    it("should return ISO string for valid dates", () => {
+      const d = new Date("2024-01-15T00:00:00.000Z");
+      expect(stringifyForLogging(d)).toBe(d.toISOString());
+    });
+
+    it("should return '<invalid date>' for invalid dates", () => {
+      expect(stringifyForLogging(new Date(Number.NaN))).toBe("<invalid date>");
+    });
+
+    it("should return JSON string for plain objects", () => {
+      expect(stringifyForLogging({ a: 1 })).toBe('{"a":1}');
+    });
+
+    it("should fall back to String() for non-object primitives", () => {
+      expect(stringifyForLogging(42)).toBe("42");
+      expect(stringifyForLogging(true)).toBe("true");
+    });
+
+    it("should not throw for objects with circular references", () => {
+      const obj: Record<string, unknown> = {};
+      obj.self = obj; // Circular reference
+      const result = stringifyForLogging(obj);
+      expect(result).toBe("[object Object]");
     });
   });
 });

--- a/tests/data-providers/OverridesDataProvider.test.ts
+++ b/tests/data-providers/OverridesDataProvider.test.ts
@@ -7,13 +7,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { Logger, LogLevel } from "../../src/core/Logger";
 import {
   OverridesByType,
   OverridesDataProvider,
   parseOverridesFile,
 } from "../../src/data-providers/OverridesDataProvider";
 
+import { Logger, LogLevel } from "../../src/core/Logger";
 Logger.setLogLevel(LogLevel.ERROR);
 
 describe("OverridesDataProvider", () => {
@@ -235,7 +235,7 @@ describe("parseOverridesFile", () => {
       iniPath,
       [
         "[ISIN.ISIN]",
-        " us0378331005 = us0378331005-new ",
+        " us0378331005 = us5949181045 ",
         "",
         "[ISIN.Symbol]",
         " aapl = us0378331005 ",
@@ -247,7 +247,7 @@ describe("parseOverridesFile", () => {
     const parsed = parseOverridesFile(iniPath);
 
     expect(parsed.isin).toBeDefined();
-    expect(parsed.isin?.isins.get("US0378331005")).toBe("US0378331005-NEW");
+    expect(parsed.isin?.isins.get("US0378331005")).toBe("US5949181045");
     expect(parsed.isin?.symbols.get("AAPL")).toBe("US0378331005");
     expect(parsed.symbol).toBeUndefined();
   });
@@ -268,7 +268,7 @@ describe("parseOverridesFile", () => {
         "aapl = us0378331005",
         "",
         "[ISIN.ISIN]",
-        "us0378331005 = us0378331005-new",
+        "us0378331005 = us5949181045",
         "",
       ].join("\n"),
       "utf-8",
@@ -282,7 +282,34 @@ describe("parseOverridesFile", () => {
 
     expect(parsed.isin).toBeDefined();
     expect(parsed.isin?.symbols.get("AAPL")).toBe("US0378331005");
-    expect(parsed.isin?.isins.get("US0378331005")).toBe("US0378331005-NEW");
+    expect(parsed.isin?.isins.get("US0378331005")).toBe("US5949181045");
+  });
+
+  it("should ignore invalid ISIN values in [ISIN.*] sections", () => {
+    const iniPath = path.join(tmpDir, "invalid-isin.ini");
+
+    fs.writeFileSync(
+      iniPath,
+      [
+        "[ISIN.ISIN]",
+        "US0378331005 = NOTANISIN",
+        "[ISIN.Symbol]",
+        "AAPL = INVALID_ISIN",
+        "[ISIN.CUSIP]",
+        "037833100 = NOT_AN_ISIN",
+        "[ISIN.Name]",
+        "APPLE INC = WRONG_ISIN",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const parsed = parseOverridesFile(iniPath);
+    expect(parsed.isin).toBeDefined();
+    expect(parsed.isin?.isins.get("US0378331005")).toBeUndefined();
+    expect(parsed.isin?.symbols.get("AAPL")).toBeUndefined();
+    expect(parsed.isin?.cusips.get("037833100")).toBeUndefined();
+    expect(parsed.isin?.names.get("APPLE INC")).toBeUndefined();
   });
 
   it("should return undefined for symbol and isin when sections are missing", () => {

--- a/tests/formats/GenericFormat.test.ts
+++ b/tests/formats/GenericFormat.test.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { bold } from "colorette";
+
 import { ActivitySubtype, ActivityType, InstrumentType } from "../../src/core/BaseFormat";
+import { Converter } from "../../src/core/Converter";
 import { SymbolDataService } from "../../src/core/SymbolDataService";
 import { OverridesDataProvider } from "../../src/data-providers";
 import { GenericFormat } from "../../src/formats/GenericFormat";
@@ -164,25 +171,6 @@ describe("Generic Format", () => {
       expect(result[2].symbol).toBe("AAPL");
     });
 
-    it("should normalize symbols to uppercase", () => {
-      const records = [
-        {
-          date: new Date("2024-01-15"),
-          transactiontype: "BUY",
-          symbol: "aapl",
-          isin: "us0378331005",
-          quantity: 100,
-          unitprice: 150.25,
-          amount: 15025,
-        },
-      ];
-
-      const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
-
-      expect(result[0].symbol).toBe("AAPL");
-      expect(result[0].isin).toBe("US0378331005");
-    });
-
     it("should handle `NaN` values", () => {
       const records = [
         {
@@ -341,7 +329,7 @@ describe("Generic Format", () => {
       });
     });
 
-    it("should throw error for unknown activity type", () => {
+    it("should warn and skip record with unknown activity type", () => {
       const records = [
         {
           date: new Date("2024-01-15"),
@@ -353,12 +341,17 @@ describe("Generic Format", () => {
         },
       ];
 
-      expect(() => format.convert(records, DEFAULT_CURRENCY, symbolDataService)).toThrow(
-        "Unknown activity type: UNKNOWN_TYPE",
-      );
+      const warnSpy = jest.spyOn(Logger.getInstance(), "warn").mockImplementation(() => undefined);
+      try {
+        const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
+        expect(result).toHaveLength(0);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown activity type"));
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
-    it("should throw error for missing activity type", () => {
+    it("should warn and skip record with missing activity type", () => {
       const records = [
         {
           date: new Date("2024-01-15"),
@@ -370,9 +363,14 @@ describe("Generic Format", () => {
         },
       ];
 
-      expect(() => format.convert(records, DEFAULT_CURRENCY, symbolDataService)).toThrow(
-        "No activity type",
-      );
+      const warnSpy = jest.spyOn(Logger.getInstance(), "warn").mockImplementation(() => undefined);
+      try {
+        const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
+        expect(result).toHaveLength(0);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No activity type"));
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it("should use total field when provided", () => {
@@ -520,6 +518,101 @@ describe("Generic Format", () => {
         fee: Number.NaN,
       });
     });
+
+    describe("special cases", () => {
+      let tmpDir: string;
+      let outputFile: string;
+      let converter: Converter;
+
+      beforeEach(() => {
+        converter = new Converter([format]);
+        symbolDataService = new SymbolDataService();
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "generic-format-test-"));
+        outputFile = path.join(tmpDir, "test-output.csv");
+      });
+
+      afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      });
+
+      it("should trim whitespace from input values", async () => {
+        const inputFile = path.join(tmpDir, "whitespace.csv");
+        fs.writeFileSync(
+          inputFile,
+          [
+            "Date,TransactionType,Symbol,Quantity,UnitPrice,Comment",
+            '2024-01-15,   buy ,  "AAPL  ","  100.5",\t120, "\nUntrimmed comment\t"',
+          ].join("\n"),
+          "utf-8",
+        );
+
+        await converter.convert(inputFile, outputFile, DEFAULT_CURRENCY, "Generic");
+
+        const content = fs.readFileSync(outputFile, "utf-8");
+        const lines = content.trim().split("\n");
+        expect(lines).toHaveLength(2); // Header + 1 data row
+
+        const headers = lines[0].split(",");
+        const symbolIndex = headers.indexOf("symbol");
+        const quantityIndex = headers.indexOf("quantity");
+        const activityTypeIndex = headers.indexOf("activityType");
+        const unitPriceIndex = headers.indexOf("unitPrice");
+        const amountIndex = headers.indexOf("amount");
+        const commentIndex = headers.indexOf("comment");
+
+        expect(symbolIndex).toBeGreaterThanOrEqual(0);
+        expect(quantityIndex).toBeGreaterThanOrEqual(0);
+        expect(activityTypeIndex).toBeGreaterThanOrEqual(0);
+        expect(unitPriceIndex).toBeGreaterThanOrEqual(0);
+        expect(amountIndex).toBeGreaterThanOrEqual(0);
+        expect(commentIndex).toBeGreaterThanOrEqual(0);
+
+        const dataRow = lines[1].split(",");
+        expect(dataRow[symbolIndex]).toBe("AAPL");
+        expect(dataRow[quantityIndex]).toBe("100.5");
+        expect(dataRow[activityTypeIndex]).toBe("BUY");
+        expect(dataRow[unitPriceIndex]).toBe("120");
+        expect(dataRow[amountIndex]).toBe("12060"); // 100.5 * 120
+        expect(dataRow[commentIndex]).toBe("Untrimmed comment");
+      });
+
+      it("should load invalid ISINs and fix the one that has overrides", async () => {
+        const inputFile = path.join(tmpDir, "invalid-isins.csv");
+        const overridesFile = path.join(tmpDir, "isin-overrides.ini");
+
+        fs.writeFileSync(
+          inputFile,
+          [
+            "Date,TransactionType,ISIN,Quantity,UnitPrice",
+            // Wrong check digit but has override
+            "2024-01-15,buy,US0378331000,100,120",
+            // Invalid ISIN without override
+            "2024-01-16,buy,INVALID_ISIN,50,200",
+          ].join("\n"),
+          "utf-8",
+        );
+        fs.writeFileSync(overridesFile, "[ISIN.ISIN]\nUS0378331000=US0378331005\n", "utf-8");
+
+        const warnSpy = jest
+          .spyOn(Logger.getInstance(), "warn")
+          .mockImplementation(() => undefined);
+
+        try {
+          await converter.convert(inputFile, outputFile, "EUR", "Generic", overridesFile);
+
+          const content = fs.readFileSync(outputFile, "utf-8");
+          const lines = content.trim().split("\n");
+          expect(lines).toHaveLength(2); // Header + 1 valid record
+          expect(lines[1]).toContain("US0378331005");
+
+          expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(`Invalid value: ${bold("INVALID_ISIN")}`),
+          );
+        } finally {
+          warnSpy.mockRestore();
+        }
+      });
+    });
   });
 
   describe("getParseOptions", () => {
@@ -558,7 +651,106 @@ describe("Generic Format", () => {
       expect(dateValue.toISOString()).toContain("2024-02-10");
       expect(quantityValue).toBe(12.5);
       expect(feeValue).toBe(1.25);
-      expect(defaultValue).toBe("abc");
+      expect(defaultValue).toBe("ABC");
+    });
+
+    it("should return normalized ISIN for a valid ISIN value", () => {
+      const options = format.getParseOptions();
+      expect(typeof options.cast).toBe("function");
+      if (typeof options.cast !== "function") {
+        return;
+      }
+
+      const cast = options.cast;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      expect(cast("us0378331005", { column: "isin", lines: 2 } as any)).toBe("US0378331005");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      expect(cast("", { column: "isin", lines: 2 } as any)).toBe("");
+    });
+
+    it("should warn and return the value as-is for an invalid ISIN value", () => {
+      const options = format.getParseOptions();
+      expect(typeof options.cast).toBe("function");
+      if (typeof options.cast !== "function") {
+        return;
+      }
+
+      const cast = options.cast;
+      const warnSpy = jest.spyOn(Logger.getInstance(), "warn").mockImplementation(() => undefined);
+
+      try {
+        // Wrong check digit
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        expect(cast("US0378331006", { column: "isin", lines: 2 } as any)).toBe("US0378331006");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        expect(cast("NOTANISIN", { column: "isin", lines: 2 } as any)).toBe("NOTANISIN");
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid ISIN"));
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("should return normalized CUSIP for a valid CUSIP value", () => {
+      const options = format.getParseOptions();
+      expect(typeof options.cast).toBe("function");
+      if (typeof options.cast !== "function") {
+        return;
+      }
+
+      const cast = options.cast;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      expect(cast("30303m102", { column: "cusip", lines: 2 } as any)).toBe("30303M102");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      expect(cast("", { column: "cusip", lines: 2 } as any)).toBe("");
+    });
+
+    it("should warn and return the value as-is for an invalid CUSIP value", () => {
+      const options = format.getParseOptions();
+      expect(typeof options.cast).toBe("function");
+      if (typeof options.cast !== "function") {
+        return;
+      }
+
+      const cast = options.cast;
+      const warnSpy = jest.spyOn(Logger.getInstance(), "warn").mockImplementation(() => undefined);
+
+      try {
+        // Wrong check digit
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        expect(cast("037833102", { column: "cusip", lines: 2 } as any)).toBe("037833102");
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        expect(cast("NOTACUSIP!", { column: "cusip", lines: 2 } as any)).toBe("NOTACUSIP!");
+
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid CUSIP"));
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("should warn and return empty string for invalid currency", () => {
+      const options = format.getParseOptions();
+      expect(typeof options.cast).toBe("function");
+      if (typeof options.cast !== "function") {
+        return;
+      }
+
+      const cast = options.cast;
+      const warnSpy = jest.spyOn(Logger.getInstance(), "warn").mockImplementation(() => undefined);
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        expect(cast("INVALID", { column: "currency", lines: 2 } as any)).toBe("");
+        // Three letters but not a valid currency code
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+        expect(cast("ZZZ", { column: "currency", lines: 2 } as any)).toBe("");
+        expect(warnSpy).toHaveBeenCalledTimes(2);
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Invalid currency code"));
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/formats/LimeCoFormat.test.ts
+++ b/tests/formats/LimeCoFormat.test.ts
@@ -905,7 +905,7 @@ describe("Lime.co Format", () => {
       expect(caster(" aapl ", { column: "symbol" })).toBe("AAPL");
       expect(caster(" BUY ", { column: "direction" })).toBe("buy");
       expect(caster(" -10.50", { column: "quantity" })).toBe(-10.5);
-      expect(caster("", { column: "price" })).toBe(0);
+      expect(caster("", { column: "price" })).toBeNaN();
       expect(caster("-1.25 ", { column: "fees" })).toBe(-1.25);
       expect(caster("-100", { column: "amount" })).toBe(-100);
       expect(caster(" note ", { column: "description" })).toBe("note");


### PR DESCRIPTION
## Description

- Refactor field validation to distinguish between three violation kinds: Valid, Unset, and Invalid. Required fields must be Valid; optional fields can be either Valid or Unset.
- Also validate optional fields in the output field validation. Contrary to the required fields, transactions with invalid optional fields will still be written, but all invalid values will be cleared.
- Validate ISIN values:
  - When loading override values: only values are checked, keys can be invalid to make it possible to use overrides to fix invalid values in the source data.
  - In the Generic format plugin during input CSV parsing: only warning is printed, but the value is still loaded. If the vlaue is not overriden or mapped, it will fail output field validation.
  - In symbol resolution results: data provider returns an invalid ISIN, the value will be treated as no resolution.
  - During output field validation: transactions with invalid values are skipped with a warning.
- Validate CUSIP values and ISO 4217 currency codes in the Generic format plugin during input CSV parsing. Invalid CUSIPs will still be loaded (to enable mapping them to valid identifiers), while invalid currency codes will be cleared (and subsequently replaced with the default currency). Both violations will produce a warning.
- Validate ISO 4217 currency codes during output field validation.
- Change Generic format plugin to skip (with a warning) records without a valid activity type instead of throwing an error and aborting the whole conversion.
- Don't trim inside the conversion code of both format plugins because their column cast function already takes care of that.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New format plugin (adds support for a new CSV format)
- [ ] New data provider (adds support for a new data source for looking up symbols, etc.)
- [x] Improvement or enhancement to existing functionality (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Chore (project maintenance, build configuration, etc.)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CODE_OF_CONDUCT.md) and agree to abide by it
- [x] I agree that my contributions will be licensed under the **BSD 3-Clause License**
- [x] My code follows the project's [coding style and conventions](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md#contributing)
- [x] I have added [JSDoc](https://jsdoc.app/) documentation for any new functions, classes, or methods
- [x] I have updated relevant documentation (README, ChangeLog, docs/, etc.)
- [x] I have written tests for my changes
- [x] All new code has adequate test coverage
- [x] All existing tests pass locally
- [x] My commits have clear and descriptive commit messages
- [x] My commits are atomic, i.e. complete and self-contained units of change (else, meld the commits before submitting the PR)

---

By submitting this pull request, I confirm that I have read and understood the [contribution guidelines](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md) and that my contributions are my own work.
