### PR TITLE
Several different fixes and improvements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -90,7 +90,7 @@ overrides file.
     part of the symbol resolution result. ISIN can be returned together with the
     symbol or on its own if the symbol cannot be resolved.
 
-- **ISIN overrides and mapping** - the overrides INI file can now also contain
+- **ISIN overrides and mapping** - The overrides INI file can now also contain
   ISIN overrides and mapping sections, which allow you to override ISIN values
   and map symbols, CUSIPs, and company names to ISINs. This allows you to
   provide a custom ISIN for a transaction that has an incorrect or missing ISIN
@@ -107,7 +107,7 @@ overrides file.
   consistent with ISIN section naming, see the breaking change in the
   **Changed** section below for more details.
 
-- **Symbol resolution caching** - once a symbol is resolved, it will be cached
+- **Symbol resolution caching** - Once a symbol is resolved, it will be cached
   in-memory for the duration of the converter's execution. This means that if
   the same symbol appears multiple times in the input CSV, it will only be
   resolved once, and all subsequent occurrences will use the cached value. The
@@ -153,7 +153,7 @@ overrides file.
   output CSV will then contain the ISIN value in the `isin` column and an empty
   value in the `symbol` column.
 
-- **Symbol normalization** - before querying providers or looking up the cache,
+- **Symbol normalization** - Before querying providers or looking up the cache,
   the converter now normalizes query fields: symbol, ISIN, and CUSIP are trimmed
   and converted to uppercase; company name is only trimmed. As a result,
   identifier values that differ only in whitespace or casing (e.g.,

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,20 @@ Upcoming release.
   - The Generic format plugin has been updated to support an optional `Tax`
     column. If not present or empty, it will be converted to an empty `tax`
     value.
+- **New `--overwrite-output` CLI option** - to allow overwriting the output file
+  if it already exists. See the breaking change below.
+
+### Changed
+
+- **BREAKING**: **Output file overwrite protection** - The converter will now
+  refuse to overwrite the output file if it already exists. You can allow
+  overwriting by using the `--overwrite-output` CLI option or setting the
+  `CTW_OVERWRITE_OUTPUT` environment variable. The default behavior has been
+  changed to prevent accidental data loss.
+- **Input and output path validation** - Input and output paths are now
+  validated to ensure that the input file exists and is readable, and that the
+  output file can be created or overwritten (if allowed). If any of these checks
+  fail, the converter will abort with an error message.
 
 ### Fixed
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,15 @@ Upcoming release.
     column. If not present or empty, it will be converted to an empty `tax`
     value.
 
+### Fixed
+
+- **Mark `quantity` field as required for staking rewards** - **Wealthfolio**
+  requires both `quantity` and `unitPrice` fields to be set for staking reward
+  interest transactions. However, this field was marked as ignored and caused it
+  to be cleared in the output CSV. As a consequence, the `amount` field is now
+  marked as optional for staking rewards, while it's still required for other
+  interest transactions.
+
 ## [0.3.0] - 2026-05-01
 
 This release adds support for the new ISIN field that was added to

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -44,6 +44,9 @@ Upcoming release.
   validated to ensure that the input file exists and is readable, and that the
   output file can be created or overwritten (if allowed). If any of these checks
   fail, the converter will abort with an error message.
+- **Ignored fields that are non-empty are now logged** - Previously, the
+  converter would silently clear non-empty ignored fields. Now, it will log them
+  with a debug message.
 
 ### Fixed
 

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -17,6 +17,7 @@ SPDX-License-Identifier: BSD-3-Clause
     - [Specify the Format Manually](#specify-the-format-manually)
     - [Specify the Default Currency](#specify-the-default-currency)
     - [Override and Resolve Symbols and ISINs](#override-and-resolve-symbols-and-isins)
+    - [Allow Overwriting the Output File](#allow-overwriting-the-output-file)
   - [List Supported Formats](#list-supported-formats)
   - [Get Format Information](#get-format-information)
   - [Get Help](#get-help)
@@ -253,6 +254,28 @@ CTW_OVERRIDES="examples/overrides.ini" convert-to-wealthfolio convert examples/s
 ```
 
 **Note:** The CLI option takes precedence over the environment variable if both are set.
+
+#### Allow Overwriting the Output File
+
+By default, the converter will refuse to overwrite the output file if it already exists. You can allow overwriting by using the `--overwrite-output true` option:
+
+```bash
+convert-to-wealthfolio convert --overwrite-output true <input.csv> <output.csv>
+```
+
+Alternatively, you can omit `true` and use `--overwrite-output` without a value to enable overwriting:
+
+```bash
+convert-to-wealthfolio convert --overwrite-output <input.csv> <output.csv>
+```
+
+You can also set the `CTW_OVERWRITE_OUTPUT` environment variable to allow overwriting:
+
+```bash
+CTW_OVERWRITE_OUTPUT=1 convert-to-wealthfolio convert <input.csv> <output.csv>
+```
+
+**Note:** Use `true`, `1`, or option with no value to enable overwriting. Use `false`, `0`, or omit the option to disable it.
 
 ### List Supported Formats
 

--- a/src/core/BaseFormat.ts
+++ b/src/core/BaseFormat.ts
@@ -195,9 +195,9 @@ export interface WealthfolioRecordMetadata {
   // Common field
   source?: {
     /// Original broker name
-    broker?: "Schwab";
+    broker?: string;
     /// Raw activity type from provider
-    original_type?: "REI";
+    original_type?: string;
   };
 }
 

--- a/src/core/Converter.ts
+++ b/src/core/Converter.ts
@@ -4,7 +4,6 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 
 import { bold, green, italic, red } from "colorette";
 import { CsvError, OptionsWithColumns, parse } from "csv-parse";
@@ -20,7 +19,14 @@ import {
 } from "./FieldRequirements";
 import { Logger } from "./Logger";
 import { SymbolDataService } from "./SymbolDataService";
-import { assertUnreachable, parseNumber, roundToPrecision, stringifyForLogging } from "./Utils";
+import {
+  assertUnreachable,
+  parseNumber,
+  roundToPrecision,
+  sanitizeInputPath,
+  sanitizeOutputPath,
+  stringifyForLogging,
+} from "./Utils";
 
 import { OverridesByType, OverridesDataProvider, parseOverridesFile } from "../data-providers";
 
@@ -97,18 +103,24 @@ export class Converter {
    * @param defaultCurrency - Default currency code to use when not specified in records
    * @param formatName - Optional format name to use (skip autodetection)
    * @param overridesPath - Optional path to overrides INI file
+   * @param overwriteOutput - Whether to allow overwriting an existing output file
    */
   async convert(
     inputPath: string,
     outputPath: string,
+    // TODO: Move to an object to reduce the parameter list
     defaultCurrency: string,
     formatName?: string,
     overridesPath?: string,
+    overwriteOutput?: boolean,
   ): Promise<void> {
     const logger = Logger.getInstance();
 
+    const sanitizedInputPath = sanitizeInputPath(inputPath);
+    const sanitizedOutputPath = sanitizeOutputPath(outputPath, overwriteOutput);
+
     // Read input CSV content
-    const fileContent = fs.readFileSync(path.resolve(inputPath), "utf-8");
+    const fileContent = fs.readFileSync(sanitizedInputPath, "utf-8");
 
     if (fileContent.trim().length === 0) {
       throw new Error("Input CSV is empty");
@@ -212,7 +224,7 @@ export class Converter {
     }
 
     // Write output CSV
-    await this.writeCSV(outputPath, convertedRecords);
+    await this.writeCSV(sanitizedOutputPath, convertedRecords);
   }
 
   /**
@@ -273,7 +285,7 @@ export class Converter {
         const columns = Object.keys(records[0]) as (keyof WealthfolioRecord)[];
         const csvContent = stringify(records, {
           header: true,
-          columns: columns,
+          columns,
           cast: {
             date: (value) =>
               // Invalid dates can't reach this point because records with invalid dates fail
@@ -288,7 +300,7 @@ export class Converter {
           },
         });
 
-        fs.writeFileSync(path.resolve(filePath), csvContent, "utf-8");
+        fs.writeFileSync(filePath, csvContent, "utf-8");
         Logger.getInstance().info(`Wrote ${bold(records.length)} records to: ${bold(filePath)}`);
         resolve();
       } catch (error) {

--- a/src/core/Converter.ts
+++ b/src/core/Converter.ts
@@ -196,6 +196,14 @@ export class Converter {
             }
           }
         }
+        if (result.ignoredFields.length > 0) {
+          logger.debug(`${bold("Clearing")} ignored fields for record ${italic(index + 1)}:`);
+          for (const field of result.ignoredFields) {
+            logger.debug(`  - ${field.name}: ${bold(stringifyForLogging(field.value))}`);
+            // WARNING: Modifies original records in-place
+            clearField(record, field.name);
+          }
+        }
         return !skip;
       });
 

--- a/src/core/FieldRequirements.ts
+++ b/src/core/FieldRequirements.ts
@@ -392,14 +392,22 @@ const RECORD_FIELD_REQUIREMENTS: {
     instrumentType: optionalWhenAssetTransactionElseIgnored,
     symbol: FieldRequirementLevel.Optional,
     isin: FieldRequirementLevel.Optional,
-    quantity: FieldRequirementLevel.Ignored,
+    quantity: (record) =>
+      // Staking reward subtype requires quantity for cost basis calculation
+      record.subtype === ActivitySubtype.StakingReward
+        ? FieldRequirementLevel.Required
+        : FieldRequirementLevel.Ignored,
     unitPrice: (record) =>
       // Staking reward subtype requires unit price (fair market value at the time of reward) for
       // cost basis calculation
       record.subtype === ActivitySubtype.StakingReward
         ? FieldRequirementLevel.Required
         : FieldRequirementLevel.Ignored,
-    amount: FieldRequirementLevel.Required,
+    amount: (record) =>
+      // Staking reward requires quantity and unit price instead of amount
+      record.subtype === ActivitySubtype.StakingReward
+        ? FieldRequirementLevel.Optional
+        : FieldRequirementLevel.Required,
     subtype: FieldRequirementLevel.Optional,
   },
   [ActivityType.Deposit]: {

--- a/src/core/FieldRequirements.ts
+++ b/src/core/FieldRequirements.ts
@@ -49,18 +49,16 @@ export interface FieldValidationResult {
 export interface RecordValidationResult {
   valid: boolean;
   invalidFields: FieldValidationResult[];
+  ignoredFields: FieldValidationResult[];
 }
 
 /**
  * Validates a Wealthfolio record against the field requirements
  */
-export function validateRecordFieldRequirements(
-  record: WealthfolioRecord,
-  clearIgnoredFields: boolean = true,
-): RecordValidationResult {
+export function validateRecordFieldRequirements(record: WealthfolioRecord): RecordValidationResult {
   const fieldRequirements = RECORD_FIELD_REQUIREMENTS[record.activityType];
   const invalidFields: FieldValidationResult[] = [];
-  const ignoredFields: (keyof WealthfolioRecord)[] = [];
+  const ignoredFields: FieldValidationResult[] = [];
 
   for (const field in fieldRequirements) {
     const fieldKey = field as keyof WealthfolioRecord;
@@ -83,20 +81,21 @@ export function validateRecordFieldRequirements(
         requirementLevel,
         violationKind,
       });
-    }
-
-    if (requirementLevel === FieldRequirementLevel.Ignored && clearIgnoredFields) {
-      ignoredFields.push(fieldKey);
+    } else if (
+      // Set fields (both valid and invalid) are marked
+      requirementLevel === FieldRequirementLevel.Ignored &&
+      violationKind !== FieldRequirementViolationKind.Unset
+    ) {
+      ignoredFields.push({
+        name: fieldKey,
+        value,
+        requirementLevel: FieldRequirementLevel.Ignored,
+        violationKind,
+      });
     }
   }
 
-  // Clear ignored fields after all validations so that requirement functions (which may also depend
-  // on ignored fields) still function correctly.
-  for (const field of ignoredFields) {
-    clearField(record, field);
-  }
-
-  return { valid: invalidFields.length === 0, invalidFields };
+  return { valid: invalidFields.length === 0, invalidFields, ignoredFields };
 }
 
 /**

--- a/src/core/Utils.ts
+++ b/src/core/Utils.ts
@@ -3,9 +3,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { trim } from "validator";
+import fs from "node:fs";
+import path from "node:path";
 
 import { bold } from "colorette";
+import { trim } from "validator";
 
 /**
  * Utility functions for CSV conversion
@@ -210,12 +212,68 @@ export function formatPair(
 }
 
 /**
+ * Verifies that the input path exists and is a file
+ *
+ * @param inputPath - The input file path to verify
+ * @returns The resolved absolute path to the input file
+ */
+export function sanitizeInputPath(inputPath: string): string {
+  const resolvedPath = path.resolve(inputPath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(`Input file does not exist: ${inputPath}`);
+  }
+
+  const fileStat = fs.statSync(resolvedPath);
+  if (!fileStat.isFile()) {
+    throw new Error(`Input path is not a file: ${inputPath}`);
+  }
+
+  return resolvedPath;
+}
+
+/**
+ * Verifies that the output path is valid
+ *
+ * Checks that the output path's parent exists and is a directory, and that the output path will be
+ * a file. Validation will also fail if the output file already exists and `overwrite` is disabled.
+ *
+ * @param outputPath - The output file path to verify
+ * @param overwrite - Whether to allow overwriting an existing file at the output path
+ * @returns The resolved absolute path to the output file
+ */
+export function sanitizeOutputPath(outputPath: string, overwrite: boolean = false): string {
+  const resolvedPath = path.resolve(outputPath);
+  const dir = path.dirname(resolvedPath);
+
+  if (!fs.existsSync(dir)) {
+    throw new Error(`Output directory does not exist: ${dir}`);
+  }
+
+  const dirStat = fs.statSync(dir);
+  if (!dirStat.isDirectory()) {
+    throw new Error(`Output path's parent is not a directory: ${dir}`);
+  }
+
+  if (fs.existsSync(resolvedPath)) {
+    const fileStat = fs.statSync(resolvedPath);
+    if (!fileStat.isFile()) {
+      throw new Error(`Output path is not a file: ${outputPath}`);
+    } else if (!overwrite) {
+      throw new Error(`Output file already exists: ${outputPath}`);
+    }
+  }
+
+  return resolvedPath;
+}
+
+/**
  * Assert that a value is of type `never`, indicating that it should be unreachable
  *
  * This function is used as a type guard to ensure that all possible cases have been handled in
  * control flow, such as in a `switch` statement. If the function is called, it will throw an error
  * indicating that an unreachable code path has been executed.
  */
+/* istanbul ignore next */
 export function assertUnreachable(_: never): never {
   throw new Error("Value is expected to be unreachable");
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,11 +86,38 @@ program
       "Path to INI file with symbol overrides and ISIN, CUSIP, and company name mappings",
     ).env("CTW_OVERRIDES"),
   )
+  .addOption(
+    new Option(
+      "--overwrite-output [value]",
+      "Allow overwriting the output file if it already exists",
+    )
+      .argParser((value) => {
+        if (value === undefined) {
+          // Default to true if the value is not provided
+          return true;
+        }
+        const normalizedValue = value.toLowerCase();
+        if (normalizedValue === "false" || normalizedValue === "0") {
+          return false;
+        } else {
+          // `choices()` below will filter out all values except "true", "false", "0", and "1"
+          return true;
+        }
+      })
+      .env("CTW_OVERWRITE_OUTPUT")
+      .choices(["true", "false", "0", "1"])
+      .default(false),
+  )
   .action(
     async (
       input: string,
       output: string,
-      options: { format?: string; defaultCurrency: string; overrides?: string },
+      options: {
+        format?: string;
+        defaultCurrency: string;
+        overrides?: string;
+        overwriteOutput?: boolean;
+      },
     ) => {
       configureLogger();
 
@@ -102,6 +129,7 @@ program
           options.defaultCurrency,
           options.format,
           options.overrides,
+          options.overwriteOutput,
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/tests/core/Converter.test.ts
+++ b/tests/core/Converter.test.ts
@@ -494,9 +494,9 @@ describe("Converter", () => {
       fs.writeFileSync(malformedFile, 'Date,Symbol\n"unclosed quote,value');
 
       // This should trigger the catch block in detectFormat
-      await expect(
-        converter.convert(malformedFile, outputFile, DEFAULT_CURRENCY),
-      ).rejects.toThrow();
+      await expect(converter.convert(malformedFile, outputFile, DEFAULT_CURRENCY)).rejects.toThrow(
+        "Cannot detect input format",
+      );
     });
 
     it("should serialize metadata and invalid dates in output CSV", async () => {
@@ -651,7 +651,7 @@ describe("Converter", () => {
             ...baseResult,
             requirementLevel: 999 as FieldRequirementLevel,
           }),
-        ).toThrow();
+        ).toThrow("Value is expected to be unreachable");
       });
     });
 
@@ -687,7 +687,7 @@ describe("Converter", () => {
             ...baseResult,
             violationKind: 999 as FieldRequirementViolationKind,
           }),
-        ).toThrow();
+        ).toThrow("Value is expected to be unreachable");
       });
     });
   });

--- a/tests/core/Converter.test.ts
+++ b/tests/core/Converter.test.ts
@@ -136,7 +136,25 @@ describe("Converter", () => {
 
       await expect(
         converter.convert(nonExistentFile, outputFile, DEFAULT_CURRENCY),
-      ).rejects.toThrow();
+      ).rejects.toThrow("Input file does not exist");
+    });
+
+    it("should throw error for non-existent output directory", async () => {
+      const inputFile = path.join(fixturesDir, "sample-generic.csv");
+      const outputInMissingDir = path.join(tmpDir, "missing-dir", "test-output.csv");
+
+      await expect(
+        converter.convert(inputFile, outputInMissingDir, DEFAULT_CURRENCY),
+      ).rejects.toThrow("Output directory does not exist");
+    });
+
+    it("should throw error when output file exists and overwrite is disabled", async () => {
+      const inputFile = path.join(fixturesDir, "sample-generic.csv");
+      fs.writeFileSync(outputFile, "already-exists.csv", "utf-8");
+
+      await expect(converter.convert(inputFile, outputFile, DEFAULT_CURRENCY)).rejects.toThrow(
+        "Output file already exists",
+      );
     });
 
     it("should throw error when no format matches", async () => {
@@ -440,15 +458,6 @@ describe("Converter", () => {
       ).rejects.toThrow("Input CSV does not match the 'Generic' format");
     });
 
-    it("should handle errors during CSV write", async () => {
-      const inputFile = path.join(fixturesDir, "sample-generic.csv");
-      const invalidOutputPath = path.join(tmpDir, "missing-dir", "output.csv");
-
-      await expect(
-        converter.convert(inputFile, invalidOutputPath, DEFAULT_CURRENCY),
-      ).rejects.toThrow();
-    });
-
     it("should rethrow when Error is caught", async () => {
       const inputFile = path.join(fixturesDir, "sample-generic.csv");
       const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {
@@ -458,6 +467,22 @@ describe("Converter", () => {
       try {
         await expect(converter.convert(inputFile, outputFile, DEFAULT_CURRENCY)).rejects.toThrow(
           "Disk full",
+        );
+      } finally {
+        writeSpy.mockRestore();
+      }
+    });
+
+    it("should wrap non-Error throws in as Error", async () => {
+      const inputFile = path.join(fixturesDir, "sample-generic.csv");
+      const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw "String error";
+      });
+
+      try {
+        await expect(converter.convert(inputFile, outputFile, DEFAULT_CURRENCY)).rejects.toThrow(
+          "String error",
         );
       } finally {
         writeSpy.mockRestore();

--- a/tests/core/FieldRequirements.test.ts
+++ b/tests/core/FieldRequirements.test.ts
@@ -10,6 +10,7 @@ import {
   WealthfolioRecord,
 } from "../../src/core/BaseFormat";
 import {
+  clearField,
   FieldRequirementViolationKind,
   validateFieldValue,
   validateRecordFieldRequirements,
@@ -109,24 +110,27 @@ describe("FieldRequirements", () => {
       expect(result.invalidFields.map((field) => field.name)).toContain("symbol");
     });
 
-    it("should clear ignored fields when requested", () => {
+    it("should report ignored fields", () => {
       const record = createRecord({
         activityType: ActivityType.Deposit,
-        // There are no ignored date and object fields, so we need to force invalid values through
-        // type assertions to test that they are cleared properly if they ever appear in the future
+        // There are no ignored date and object fields, so force these values through type
+        // assertions to verify that they are reported if they ever appear in the future
         symbol: new Date("2024-01-01") as unknown as string,
         isin: { note: "ignored" } as unknown as string,
       });
 
-      const result = validateRecordFieldRequirements(record, true);
+      const result = validateRecordFieldRequirements(record);
 
       expect(result.valid).toBe(true);
       expect(record.symbol).toBeInstanceOf(Date);
-      expect((record.symbol as unknown as Date).getTime()).toBeNaN();
-      expect(record.isin).toEqual({});
+      expect((record.symbol as unknown as Date).getTime()).toBe(new Date("2024-01-01").getTime());
+      expect(record.isin).toEqual({ note: "ignored" });
+      expect(result.ignoredFields.map((field) => field.name)).toEqual(
+        expect.arrayContaining(["symbol", "isin", "quantity", "unitPrice"]),
+      );
     });
 
-    it("should clear ignored numeric fields", () => {
+    it("should report ignored numeric fields", () => {
       const record = createRecord({
         activityType: ActivityType.Deposit,
         symbol: "",
@@ -135,31 +139,40 @@ describe("FieldRequirements", () => {
         amount: 100,
       });
 
-      const result = validateRecordFieldRequirements(record, true);
-
-      expect(result.valid).toBe(true);
-      expect(record.symbol).toBe("");
-      expect(record.quantity).toBeNaN();
-      expect(record.unitPrice).toBeNaN();
-      expect(record.amount).toBe(100);
-    });
-
-    it("should keep ignored fields when not requested", () => {
-      const record = createRecord({
-        activityType: ActivityType.Deposit,
-        symbol: "",
-        quantity: 5,
-        unitPrice: 2,
-        amount: 100,
-      });
-
-      const result = validateRecordFieldRequirements(record, false);
+      const result = validateRecordFieldRequirements(record);
 
       expect(result.valid).toBe(true);
       expect(record.symbol).toBe("");
       expect(record.quantity).toBe(5);
       expect(record.unitPrice).toBe(2);
       expect(record.amount).toBe(100);
+      expect(result.ignoredFields.map((field) => field.name)).toEqual(
+        expect.arrayContaining(["quantity", "unitPrice"]),
+      );
+    });
+
+    it("should not report unset ignored fields", () => {
+      const record = createRecord({
+        activityType: ActivityType.Deposit,
+        symbol: "",
+        quantity: 5,
+        unitPrice: 2,
+        amount: 100,
+      });
+
+      const result = validateRecordFieldRequirements(record);
+
+      expect(result.valid).toBe(true);
+      expect(record.symbol).toBe("");
+      expect(record.quantity).toBe(5);
+      expect(record.unitPrice).toBe(2);
+      expect(record.amount).toBe(100);
+
+      const ignoredFieldNames = result.ignoredFields.map((field) => field.name);
+      expect(ignoredFieldNames).toEqual(expect.arrayContaining(["quantity", "unitPrice"]));
+      expect(ignoredFieldNames).not.toContain("symbol");
+      expect(ignoredFieldNames).not.toContain("isin");
+      expect(ignoredFieldNames).not.toContain("tax");
     });
 
     it("should enforce conditional requirements", () => {
@@ -310,14 +323,14 @@ describe("FieldRequirements", () => {
           amount: 100,
         });
 
-        const result = validateRecordFieldRequirements(record, true);
+        const result = validateRecordFieldRequirements(record);
 
         expect(result.valid).toBe(true);
         expect(record.subtype).toBe(subtype);
       }
     });
 
-    it("should clear subtype for activities where subtype is ignored", () => {
+    it("should report ignored subtype for activities where subtype is ignored", () => {
       const cases: ActivityType[] = [
         ActivityType.Buy,
         ActivityType.Sell,
@@ -336,10 +349,11 @@ describe("FieldRequirements", () => {
           amount: 100,
         });
 
-        const result = validateRecordFieldRequirements(record, true);
+        const result = validateRecordFieldRequirements(record);
 
         expect(result.valid).toBe(true);
-        expect(record.subtype).toBe("");
+        expect(record.subtype).toBe(ActivitySubtype.DRIP);
+        expect(result.ignoredFields.map((field) => field.name)).toContain("subtype");
       }
     });
 
@@ -405,8 +419,8 @@ describe("FieldRequirements", () => {
         isin: "US0378331005",
       });
 
-      const resultSymbol = validateRecordFieldRequirements(recordSymbol, true);
-      const resultISIN = validateRecordFieldRequirements(recordISIN, true);
+      const resultSymbol = validateRecordFieldRequirements(recordSymbol);
+      const resultISIN = validateRecordFieldRequirements(recordISIN);
 
       expect(resultSymbol.valid).toBe(true);
       expect(resultISIN.valid).toBe(true);
@@ -414,7 +428,7 @@ describe("FieldRequirements", () => {
       expect(recordISIN.instrumentType).toBe(InstrumentType.Equity);
     });
 
-    it("should ignore instrument type for adjustment activity when symbol and ISIN are missing", () => {
+    it("should report ignored instrument type for adjustment activity when symbol and ISIN are missing", () => {
       const record = createRecord({
         activityType: ActivityType.Adjustment,
         instrumentType: InstrumentType.Equity,
@@ -422,10 +436,11 @@ describe("FieldRequirements", () => {
         isin: "",
       });
 
-      const result = validateRecordFieldRequirements(record, true);
+      const result = validateRecordFieldRequirements(record);
 
       expect(result.valid).toBe(true);
-      expect(record.instrumentType).toBe(InstrumentType.Unknown);
+      expect(record.instrumentType).toBe(InstrumentType.Equity);
+      expect(result.ignoredFields.map((field) => field.name)).toContain("instrumentType");
     });
 
     it("should keep instrument type for unknown activity when symbol or ISIN is present", () => {
@@ -440,8 +455,8 @@ describe("FieldRequirements", () => {
         isin: "US0378331005",
       });
 
-      const resultSymbol = validateRecordFieldRequirements(recordSymbol, true);
-      const resultISIN = validateRecordFieldRequirements(recordISIN, true);
+      const resultSymbol = validateRecordFieldRequirements(recordSymbol);
+      const resultISIN = validateRecordFieldRequirements(recordISIN);
 
       expect(resultSymbol.valid).toBe(true);
       expect(resultISIN.valid).toBe(true);
@@ -449,7 +464,7 @@ describe("FieldRequirements", () => {
       expect(recordISIN.instrumentType).toBe(InstrumentType.Equity);
     });
 
-    it("should ignore instrument type for unknown activity when symbol and ISIN are missing", () => {
+    it("should report ignored instrument type for unknown activity when symbol and ISIN are missing", () => {
       const record = createRecord({
         activityType: ActivityType.Unknown,
         instrumentType: InstrumentType.Equity,
@@ -457,10 +472,33 @@ describe("FieldRequirements", () => {
         isin: "",
       });
 
-      const result = validateRecordFieldRequirements(record, true);
+      const result = validateRecordFieldRequirements(record);
 
       expect(result.valid).toBe(true);
-      expect(record.instrumentType).toBe(InstrumentType.Unknown);
+      expect(record.instrumentType).toBe(InstrumentType.Equity);
+      expect(result.ignoredFields.map((field) => field.name)).toContain("instrumentType");
+    });
+  });
+
+  describe("clearField", () => {
+    it("should clear a field in a record", () => {
+      const record = createRecord({
+        symbol: "AAPL",
+        quantity: 10,
+        unitPrice: 150,
+        metadata: { source: { broker: "Foobar" } },
+      });
+
+      clearField(record, "symbol"); // string
+      clearField(record, "quantity"); // number
+      clearField(record, "date"); // Date object
+      clearField(record, "metadata"); // generic object
+
+      expect(record.symbol).toBe("");
+      expect(record.quantity).toBeNaN();
+      expect(record.date).toBeInstanceOf(Date);
+      expect(record.date.getTime()).toBeNaN();
+      expect(record.metadata).toEqual({});
     });
   });
 });

--- a/tests/core/Utils.test.ts
+++ b/tests/core/Utils.test.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { bold } from "colorette";
 
 import {
@@ -11,7 +15,9 @@ import {
   isCUSIP,
   parseNumber,
   roundToPrecision,
+  sanitizeInputPath,
   sanitizeName,
+  sanitizeOutputPath,
   stringifyForLogging,
 } from "../../src/core/Utils";
 
@@ -289,6 +295,114 @@ describe("Utils", () => {
       obj.self = obj; // Circular reference
       const result = stringifyForLogging(obj);
       expect(result).toBe("[object Object]");
+    });
+  });
+
+  describe("path sanitizers", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "utils-path-test-"));
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe("sanitizeInputPath", () => {
+      it("should resolve valid paths without throwing", () => {
+        const validInput = path.join(tmpDir, "valid-input.csv");
+        fs.writeFileSync(validInput, "test", "utf-8");
+
+        expect(() => sanitizeInputPath(validInput)).not.toThrow();
+      });
+
+      it("should throw when input file does not exist", () => {
+        const missingInput = path.join(tmpDir, "missing-input.csv");
+
+        expect(() => sanitizeInputPath(missingInput)).toThrow("Input file does not exist");
+      });
+
+      it("should throw when input path points to a directory", () => {
+        expect(() => sanitizeInputPath(tmpDir)).toThrow("Input path is not a file");
+      });
+    });
+
+    describe("sanitizeOutputPath", () => {
+      it("should resolve when output file's directory exists while it doesn't", () => {
+        // Non-existing file in the existing directory
+        expect(() => sanitizeOutputPath(path.join(tmpDir, "valid-output.csv"))).not.toThrow();
+      });
+
+      it("should resolve when output file already exists and overwrite is enabled", () => {
+        const validOutput = path.join(tmpDir, "valid-output.csv");
+        fs.writeFileSync(validOutput, "test", "utf-8");
+
+        expect(() => sanitizeOutputPath(validOutput, true)).not.toThrow();
+      });
+
+      it("should throw when output file already exists and overwrite is disabled", () => {
+        const outputPath = path.join(tmpDir, "output.csv");
+        fs.writeFileSync(outputPath, "existing", "utf-8");
+
+        expect(() => sanitizeOutputPath(outputPath)).toThrow("Output file already exists");
+      });
+
+      it("should throw when output directory does not exist", () => {
+        const missingParentOutput = path.join(tmpDir, "missing-parent", "output.csv");
+
+        expect(() => sanitizeOutputPath(missingParentOutput)).toThrow(
+          "Output directory does not exist",
+        );
+      });
+
+      it("should throw when parent path is not a directory", () => {
+        const outputPath = path.join(tmpDir, "output.csv");
+
+        const existsSpy = jest.spyOn(fs, "existsSync").mockImplementation(() => true);
+        const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => {
+          return {
+            isDirectory: () => false,
+            isFile: () => false,
+          } as fs.Stats;
+        });
+
+        try {
+          expect(() => sanitizeOutputPath(outputPath)).toThrow(
+            "Output path's parent is not a directory",
+          );
+
+          expect(existsSpy).toHaveBeenCalledTimes(1);
+          expect(statSpy).toHaveBeenCalledTimes(1);
+        } finally {
+          existsSpy.mockRestore();
+          statSpy.mockRestore();
+        }
+      });
+
+      it("should throw when output path exists but is not a file", () => {
+        const outputPath = path.join(tmpDir, "output.csv");
+
+        const existsSpy = jest.spyOn(fs, "existsSync").mockImplementation(() => true);
+        const statSpy = jest.spyOn(fs, "statSync").mockImplementation(() => {
+          return {
+            isDirectory: () => true,
+            isFile: () => false,
+          } as fs.Stats;
+        });
+
+        try {
+          expect(() => sanitizeOutputPath(outputPath)).toThrow("Output path is not a file");
+
+          // Once for the parent directory and once for the output file
+          expect(existsSpy).toHaveBeenCalledTimes(2);
+          expect(statSpy).toHaveBeenCalledTimes(2);
+        } finally {
+          existsSpy.mockRestore();
+          statSpy.mockRestore();
+        }
+      });
     });
   });
 });

--- a/tests/formats/GenericFormat.test.ts
+++ b/tests/formats/GenericFormat.test.ts
@@ -251,11 +251,40 @@ describe("Generic Format", () => {
           quantity: 100,
           unitprice: 150.25,
         },
+        {
+          date: new Date("2024-01-20"),
+          transactiontype: "SELL",
+          symbol: "AAPL",
+          quantity: 50,
+          unitprice: 152.5,
+          fee: 5,
+        },
+        {
+          date: new Date("2024-02-01"),
+          transactiontype: "BUY",
+          symbol: "MSFT",
+          quantity: 200,
+          unitprice: 250.75,
+          tax: 10,
+        },
+        {
+          date: new Date("2024-02-10"),
+          transactiontype: "SELL",
+          symbol: "MSFT",
+          quantity: 100,
+          unitprice: 255.5,
+          fee: 2.5,
+          tax: 50,
+        },
       ];
 
       const result = format.convert(records, DEFAULT_CURRENCY, symbolDataService);
 
+      // Amount should not include fee or tax
       expect(result[0].amount).toBe(100 * 150.25);
+      expect(result[1].amount).toBe(50 * 152.5);
+      expect(result[2].amount).toBe(200 * 250.75);
+      expect(result[3].amount).toBe(100 * 255.5);
     });
 
     it("should map activity types correctly", () => {


### PR DESCRIPTION
## Description

1. Mark `quantity` field as required for staking rewards

   Both `quantity` and `unitPrice` fields are required for staking reward interest transactions.

   Also mark the `amount` field as optional for staking rewards.

2. Input and output path validation and output overwrite protection

   1. Validate input and output paths:

      - input path should exist and be a file;
      - output path should be in an existing directory and either not exist, or be a file.

      This addresses SonarQube warnings about user input validation.

   2. Refuse to overwrite an already existing output file, unless `--overwrite-output` argument is specified.

3. Log non-empty ignored fields

   In addition to that, don't clear ignored fields in the `validateRecordFieldRequirements()`. Instead, return them in the `ignoredFields` property and clear them on the converter side.

   Also fix the metadata schema.

4. Several small improvements:
    
   - Fix capitalization in the ChangeLog.
   - Add tax and fee variations to the Generic format amount calculation unit test.
   - Add errors messages to throw checks in the unit tests.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New format plugin (adds support for a new CSV format)
- [ ] New data provider (adds support for a new data source for looking up symbols, etc.)
- [x] Improvement or enhancement to existing functionality (non-breaking change)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Code refactoring (no functional changes)
- [x] Test improvements
- [ ] Chore (project maintenance, build configuration, etc.)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [Code of Conduct](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CODE_OF_CONDUCT.md) and agree to abide by it
- [x] I agree that my contributions will be licensed under the **BSD 3-Clause License**
- [x] My code follows the project's [coding style and conventions](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md#contributing)
- [x] I have added [JSDoc](https://jsdoc.app/) documentation for any new functions, classes, or methods
- [x] I have updated relevant documentation (README, ChangeLog, docs/, etc.)
- [x] I have written tests for my changes
- [x] All new code has adequate test coverage
- [x] All existing tests pass locally
- [x] My commits have clear and descriptive commit messages
- [x] My commits are atomic, i.e. complete and self-contained units of change (else, meld the commits before submitting the PR)

---

By submitting this pull request, I confirm that I have read and understood the [contribution guidelines](https://github.com/leppa/convert-to-wealthfolio/blob/dev/CONTRIBUTING.md) and that my contributions are my own work.
